### PR TITLE
Fix single table inheritance classkey type

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -10,6 +10,7 @@ namespace Propel\Generator\Builder\Om;
 
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\IdMethod;
+use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\PlatformInterface;
 
 /**
@@ -348,26 +349,31 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             return;
         }
 
+        $isNumericKey = $col->isNumericType() && $col->getType() !== PropelTypes::DECIMAL;
+
         foreach ($col->getChildren() as $child) {
             $childBuilder = $this->getMultiExtendObjectBuilder();
             $childBuilder->setChild($child);
             $fqcn = addslashes($childBuilder->getFullyQualifiedClassName());
 
+            $suffix = $child->getConstantSuffix();
+            $key = $isNumericKey ? $child->getKey() : "'" . $child->getKey() . "'";
             $script .= "
     /** A key representing a particular subclass */
-    public const CLASSKEY_" . $child->getConstantSuffix() . " = '" . $child->getKey() . "';
+    public const CLASSKEY_{$suffix} = $key;
 ";
 
             if (strtoupper($child->getClassName()) != $child->getConstantSuffix()) {
+                $childClassLiteral = strtoupper($child->getClassname());
                 $script .= "
     /** A key representing a particular subclass */
-    public const CLASSKEY_" . strtoupper($child->getClassname()) . " = '" . $fqcn . "';
+    public const CLASSKEY_{$childClassLiteral} = '$fqcn';
 ";
             }
 
             $script .= "
     /** A class that can be returned by this tableMap. */
-    public const CLASSNAME_" . $child->getConstantSuffix() . " = '" . $fqcn . "';
+    public const CLASSNAME_{$suffix} = '$fqcn';
 ";
         }
     }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -206,7 +206,7 @@ class Column extends MappingModel
     private $isEnumeratedClasses = false;
 
     /**
-     * @var array|null
+     * @var array<\Propel\Generator\Model\Inheritance>|null
      */
     private $inheritanceList;
 
@@ -845,7 +845,7 @@ class Column extends MappingModel
     /**
      * Returns the inheritance list.
      *
-     * @return array|null
+     * @return array<\Propel\Generator\Model\Inheritance>|null
      */
     public function getInheritanceList(): ?array
     {
@@ -855,11 +855,11 @@ class Column extends MappingModel
     /**
      * Returns the inheritance definitions.
      *
-     * @return array|null
+     * @return array<\Propel\Generator\Model\Inheritance>|null
      */
     public function getChildren(): ?array
     {
-        return $this->inheritanceList;
+        return $this->getInheritanceList();
     }
 
     /**


### PR DESCRIPTION
When using [single table inheritance](https://propelorm.org/documentation/08-inheritance.html#single-table-inheritance), the keys for the individual classes are written to the TableMap as constants. Those are used during instantiation of the subclasses.

For example, an inheritance declaration like
```xml
        <column name="type_indicator"  inheritance="single">
            <inheritance key="firstClassIdentifier" class="..." extends="..."/>
        </column>
```
will create a constant in the TableMap:
```php
    public const CLASSKEY_FIRSTCLASSIDENTIFIER = 'firstClassIdentifier';
```
and a constructor of the subclass:
```php
    public function __construct()
    {
        parent::__construct();
        $this->setTypeIndicator(FooTableMap::CLASSKEY_FIRSTCLASSIDENTIFIER);
    }
``` 

The value of the classkey constant is always written as a string, even for numeric values:
```php
    public const CLASSKEY_1 = '1';'
```

This leads to a type error in the generated constructor code, since the setter function for the numeric field will expect a numeric value.

With the changes in this PR, numeric class key constants are written as numeric values, fixing the type error.