### PR TITLE
Feature/output group

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3150,7 +3150,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *  'localVariableName': string,
      *  'relationName': string,
      *  'targetKeyLookupStatement': string,
-     *  'isCollection': bool
+     *  'isCollection': bool,
+     *  'relationId': string
      * }>
      */
     protected function buildRelationFormatterData(): array
@@ -3165,6 +3166,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
                 'relationName' => $this->getFKPhpNameAffix($fk),
                 'targetKeyLookupStatement' => $lookup,
                 'isCollection' => false,
+                'relationId' => $fk->getName(),
             ];
         }
 
@@ -3180,6 +3182,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
                 'relationName' => $relationName,
                 'targetKeyLookupStatement' => $lookup,
                 'isCollection' => !$isLocal,
+                'relationId' => $ref->getName(),
             ];
         }
 

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -223,6 +223,11 @@ class Column extends MappingModel
     protected $valueSet = [];
 
     /**
+     * @var array<string>
+     */
+    protected $outputGroupNames = [];
+
+    /**
      * Creates a new column and set the name.
      *
      * @param string $name The column's name
@@ -336,6 +341,8 @@ class Column extends MappingModel
             // AutoIncrement/Sequences
             $this->isAutoIncrement = $this->booleanValue($this->getAttribute('autoIncrement'));
             $this->isLazyLoad = $this->booleanValue($this->getAttribute('lazyLoad'));
+
+            $this->outputGroupNames = $this->getDefaultValueForSet($this->getAttribute('outputGroup', '')) ?? [];
 
             // Add type, size information to associated Domain object
             $domain->replaceSqlType($this->getAttribute('sqlType'));
@@ -1684,6 +1691,24 @@ class Column extends MappingModel
         }
 
         return $this->parentTable->getPlatform() ? true : false;
+    }
+
+    /**
+     * @param array<string> $outputGroupNames
+     *
+     * @return void
+     */
+    public function setOutputGroupNames(array $outputGroupNames)
+    {
+        $this->outputGroupNames = $outputGroupNames;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getOutputGroupNames(): array
+    {
+        return $this->outputGroupNames;
     }
 
     /**

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -131,6 +131,16 @@ class ForeignKey extends MappingModel
     private $autoNaming = false;
 
     /**
+     * @var array<string>
+     */
+    protected $localOutputGroupNames = [];
+
+    /**
+     * @var array<string>
+     */
+    protected $refOutputGroupNames = [];
+
+    /**
      * Constructs a new ForeignKey object.
      *
      * @param string|null $name
@@ -161,6 +171,9 @@ class ForeignKey extends MappingModel
         $this->onUpdate = $this->normalizeFKey($this->getAttribute('onUpdate'));
         $this->onDelete = $this->normalizeFKey($this->getAttribute('onDelete'));
         $this->skipSql = $this->booleanValue($this->getAttribute('skipSql'));
+
+        $this->localOutputGroupNames = $this->getDefaultValueForSet($this->getAttribute('outputGroup', '')) ?? [];
+        $this->refOutputGroupNames = $this->getDefaultValueForSet($this->getAttribute('refOutputGroup', '')) ?? [];
     }
 
     /**
@@ -1127,5 +1140,41 @@ class ForeignKey extends MappingModel
         $cols = $this->getLocalPrimaryKeys();
 
         return count($cols) !== 0;
+    }
+
+    /**
+     * @param array<string> $outputGroupNames
+     *
+     * @return void
+     */
+    public function setLocalOutputGroupNames(array $outputGroupNames)
+    {
+        $this->localOutputGroupNames = $outputGroupNames;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getLocalOutputGroupNames(): array
+    {
+        return $this->localOutputGroupNames;
+    }
+
+    /**
+     * @param array<string> $outputGroupNames
+     *
+     * @return void
+     */
+    public function setRefOutputGroupNames(array $outputGroupNames)
+    {
+        $this->refOutputGroupNames = $outputGroupNames;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRefOutputGroupNames(): array
+    {
+        return $this->refOutputGroupNames;
     }
 }

--- a/src/Propel/Runtime/ActiveRecord/ActiveRecordInterface.php
+++ b/src/Propel/Runtime/ActiveRecord/ActiveRecordInterface.php
@@ -14,6 +14,7 @@ namespace Propel\Runtime\ActiveRecord;
  * @author jaugustin
  *
  * @method array toArray(string $keyType = \Propel\Runtime\Map\TableMap::TYPE_FIELDNAME, bool $includeLazyLoadColumns = true, array $alreadyDumpedObjects = [], bool $includeForeignObjects = false): array
+ * @method array toOutputGroup($outputGroup, string $keyType = \Propel\Runtime\Map\TableMap::TYPE_FIELDNAME, array $alreadyDumpedObjects = []): array
  */
 interface ActiveRecordInterface
 {

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -211,6 +211,40 @@ class ObjectCollection extends Collection
     }
 
     /**
+     * Turn collection objects into arrays with values specified by output group.
+     *
+     * @param array<string, string>|string $outputGroup Name of the output group used for all tables or
+     *                                                  an array mapping model classes to output group name.
+     *                                                  If a model class does not have a definition for the
+     *                                                  given output group, the whole data is returned.
+     * @param string|null $keyColumn (optional) Column name to use as index.
+     * @param string $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME,
+     *                                        TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME,
+     *                                        TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
+     * @param array $alreadyDumpedObjects Internally used on recursion, typically not set by user (List of
+     *                                      objects to skip to avoid recursion).
+     *
+     * @return array
+     */
+    public function toOutputGroup(
+        $outputGroup,
+        ?string $keyColumn = null,
+        string $keyType = TableMap::TYPE_PHPNAME,
+        array $alreadyDumpedObjects = []
+    ): array {
+        $ret = [];
+        $keyGetterMethod = 'get' . $keyColumn;
+
+        /** @var \Propel\Runtime\ActiveRecord\ActiveRecordInterface $obj */
+        foreach ($this->data as $key => $obj) {
+            $key = (!$keyColumn) ? $key : $obj->$keyGetterMethod();
+            $ret[$key] = $obj->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+        }
+
+        return $ret;
+    }
+
+    /**
      * Get an array representation of the collection
      *
      * @param string|null $keyColumn If null, the returned array uses an incremental index.

--- a/templates/Builder/Om/baseObjectToOutputGroup.php
+++ b/templates/Builder/Om/baseObjectToOutputGroup.php
@@ -1,0 +1,68 @@
+
+    /**
+     * Export subset of object fields as specified by output group.
+     *
+     * @param string|array<string,string> $outputGroup  Name of the output group used for all tables or 
+     *                                                  an array mapping model classes to output group name.
+     *                                                  If a model class does not have a definition for the
+     *                                                  given output group, the whole data is returned.
+     * @param string $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME,
+     *                                        TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME,
+     *                                        TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
+     * @param array $alreadyDumpedObjects   Internally used on recursion, typically not set by user (List of 
+     *                                      objects to skip to avoid recursion).
+     * @return array
+     */
+    public function toOutputGroup(
+        $outputGroup,
+        string $keyType = TableMap::TYPE_PHPNAME,
+        array $alreadyDumpedObjects = []
+    ): array
+    {
+        if (isset($alreadyDumpedObjects['<?= $objectClassName ?>'][$this->hashCode()])) {
+            return ['*RECURSION*'];
+        }
+        $alreadyDumpedObjects['<?= $objectClassName ?>'][$this->hashCode()] = true;
+        $keys = <?= $tableMapClassName ?>::getFieldNames($keyType);
+        $outputGroupName = is_string($outputGroup) ? $outputGroup : $outputGroup[get_class($this)] ?? $outputGroup['default'] ?? '';
+        [
+            'column_index' => $columnIndexes, 
+            'relation' => $relationsLookup
+        ] = <?= $tableMapClassName ?>::getOutputGroupData($outputGroupName);
+        $result = [];
+
+        foreach($columnIndexes as $columnIndex){
+            $columnName = $keys[$columnIndex];
+            $columnValue = $this->getByPosition($columnIndex);
+            $result[$columnName] = $columnValue;
+        }
+
+<?php
+    foreach($temporalColumnIndexesByFormatter as $formatter => $indexes):
+        foreach($indexes as $index):
+?>
+        if (($result[$keys[<?= $index ?>]] ?? null) instanceof \DateTimeInterface) {
+            $result[$keys[<?= $index ?>]] = $result[$keys[<?= $index ?>]]->format('<?= $formatter ?>');
+        }
+<?php
+        endforeach;
+    endforeach;
+?>
+        $virtualColumns = $this->virtualColumns;
+        foreach ($virtualColumns as $key => $virtualColumn) {
+            $result[$key] = $virtualColumn;
+        }
+<?php foreach($relationFormatterData as $relationFormatter): ?>
+
+        if ($this-><?= $relationFormatter['localVariableName'] ?> !== null && ($relationsLookup === null || isset($relationsLookup['<?= $relationFormatter['relationName'] ?>']))) {
+            <?= $relationFormatter['targetKeyLookupStatement'] ?>
+<?php if ($relationFormatter['isCollection']): // call ObjectCollection::toOutputGroup() ?>
+            $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, null, $keyType, $alreadyDumpedObjects);
+<?php else: // call Model::toOutputGroup() (this method) ?>
+            $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+<?php endif ?>
+        }
+<?php endforeach;?>
+
+        return $result;
+    }

--- a/templates/Builder/Om/baseObjectToOutputGroup.php
+++ b/templates/Builder/Om/baseObjectToOutputGroup.php
@@ -52,19 +52,27 @@
         foreach ($virtualColumns as $key => $virtualColumn) {
             $result[$key] = $virtualColumn;
         }
-<?php foreach($relationFormatterData as $relationFormatter): ?>
+<?php foreach($relationFormatterData as $relationFormatter): 
+    [
+        'localVariableName' => $localVariableName,
+        'relationName' => $relationName,
+        'targetKeyLookupStatement' => $targetKeyLookupStatement,
+        'isCollection' => $isCollection,
+        'relationId' => $relationId,
+    ] = $relationFormatter;
 
-        if ($this-><?= $relationFormatter['localVariableName'] ?> !== null && ($relationsLookup === null || isset($relationsLookup['<?= $relationFormatter['relationName'] ?>']))) {
-            <?= $relationFormatter['targetKeyLookupStatement'] ?>
-<?php if ($relationFormatter['isCollection']): // call ObjectCollection::toOutputGroup() ?>
-            $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, null, $keyType, $alreadyDumpedObjects);
-<?php else: // call Model::toOutputGroup() (this method) ?>
-    
-            if (!isset($alreadyDumpedObjects['<?= $relationFormatter['relationId'] ?>'][$this-><?= $relationFormatter['localVariableName']?>->hashCode()])){
-                $alreadyDumpedObjects['<?= $relationFormatter['relationId'] ?>'][$this-><?= $relationFormatter['localVariableName']?>->hashCode()] = 1;
-                $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+    $hashSource = $isCollection ? '$this' : '$this->' . $localVariableName;
+    $dumpedLookupStatement = "\$alreadyDumpedObjects['{$relationId}'][{$hashSource}->hashCode()]";
+    $outputGroupArgsStatement = $isCollection ? '$outputGroup, null, $keyType, $alreadyDumpedObjects' : '$outputGroup, $keyType, $alreadyDumpedObjects'
+?>
+
+        if ($this-><?= $localVariableName ?> !== null && ($relationsLookup === null || isset($relationsLookup['<?= $relationName ?>']))) {
+            <?= $targetKeyLookupStatement ?>
+
+            if (!isset(<?= $dumpedLookupStatement ?>)){
+                <?= $dumpedLookupStatement ?> = 1;
+                $result[$key] = $this-><?= $localVariableName ?>->toOutputGroup(<?= $outputGroupArgsStatement ?>);
             }
-<?php endif ?>
         }
 <?php endforeach;?>
 

--- a/templates/Builder/Om/baseObjectToOutputGroup.php
+++ b/templates/Builder/Om/baseObjectToOutputGroup.php
@@ -59,7 +59,11 @@
 <?php if ($relationFormatter['isCollection']): // call ObjectCollection::toOutputGroup() ?>
             $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, null, $keyType, $alreadyDumpedObjects);
 <?php else: // call Model::toOutputGroup() (this method) ?>
-            $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+    
+            if (!isset($alreadyDumpedObjects['<?= $relationFormatter['relationId'] ?>'][$this-><?= $relationFormatter['localVariableName']?>->hashCode()])){
+                $alreadyDumpedObjects['<?= $relationFormatter['relationId'] ?>'][$this-><?= $relationFormatter['localVariableName']?>->hashCode()] = 1;
+                $result[$key] = $this-><?= $relationFormatter['localVariableName'] ?>->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+            }
 <?php endif ?>
         }
 <?php endforeach;?>

--- a/templates/Builder/Om/tableMapOutputGroups.php
+++ b/templates/Builder/Om/tableMapOutputGroups.php
@@ -1,0 +1,33 @@
+
+    /**
+     * Output group definitions.
+     *
+     * @var array<string, array{'column_index': array<int>, 'relation': array<int>}>
+     */
+    protected static $outputGroups = [
+<?php foreach ($columnIndexesByOutputGroup as $outputGroupName => $values):?>
+        '<?= $outputGroupName ?>' => [
+            'column_index' => [<?= implode(', ', $values['column_index'] ?? []) ?>],
+            'relation' => [
+<?php foreach($values['relation'] ?? [] as $relationName): ?>
+                '<?= $relationName ?>' => 1,
+<?php endforeach; ?>
+            ],
+        ],
+<?php endforeach; ?>
+    ];
+
+    /**
+     * Get column indexes for the given output group name.
+     *
+     * @param string $outputGroupName Name of the output group as specified in schema.xml.
+     *
+     * @return array<string, array{'column_index': array<int>, 'relation': array<int>|null}>
+     */
+    public static function getOutputGroupData(string $outputGroupName): array
+    {
+        return self::$outputGroups[$outputGroupName] ?? [
+            'column_index' => self::$fieldKeys[self::TYPE_NUM],
+            'relation' => null,
+        ];
+    }

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -150,14 +150,14 @@
     <!-- test self-referencing foreign keys and inheritance-->
     <table name="bookstore_employee"
         description="Hierarchical table to represent employees of a bookstore.">
-        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" description="Employee ID number"/>
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" description="Employee ID number" outputGroup="short"/>
         <column name="class_key" type="INTEGER" required="true" default="0" inheritance="single">
             <inheritance key="0" class="BookstoreEmployee"/>
             <inheritance key="1" class="BookstoreManager" extends="BookstoreEmployee"/>
             <inheritance key="2" class="BookstoreCashier" extends="BookstoreEmployee"/>
             <inheritance key="3" class="BookstoreHead" extends="BookstoreManager"/>
         </column>
-        <column name="name" type="VARCHAR" size="32" description="Employee name"/>
+        <column name="name" type="VARCHAR" size="32" description="Employee name" outputGroup="short"/>
         <column name="job_title" type="VARCHAR" size="32" description="Employee job title"/>
         <column name="supervisor_id" type="INTEGER" description="Fkey to supervisor."/>
         <column name="photo" type="BLOB" lazyLoad="true"/>
@@ -168,19 +168,19 @@
 
     <!-- Test one-to-one (1:1) relationship, default values -->
     <table name="bookstore_employee_account" reloadOnInsert="true" reloadOnUpdate="true" description="Bookstore employees login credentials.">
-        <column name="employee_id" type="INTEGER" primaryKey="true" description="Primary key for the account ..."/>
-        <column name="login" type="VARCHAR" size="32"/>
+        <column name="employee_id" type="INTEGER" primaryKey="true" description="Primary key for the account ..." outputGroup="public,short"/>
+        <column name="login" type="VARCHAR" size="32" outputGroup="public,short"/>
         <column name="password" type="VARCHAR" size="100" default="'@''34&quot;"/>
         <column name="enabled" type="BOOLEAN" default="true"/>
         <column name="not_enabled" type="BOOLEAN" default="false"/>
-        <column name="created" type="TIMESTAMP" defaultExpr="CURRENT_TIMESTAMP"/>
+        <column name="created" type="TIMESTAMP" defaultExpr="CURRENT_TIMESTAMP" outputGroup="public"/>
         <column name="updated" type="TIMESTAMP" defaultExpr="CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"/>
-        <column name="role_id" type="INTEGER" required="false" default="null"/>
-        <column name="authenticator" type="VARCHAR" size="32" defaultExpr="'Password'"/>
-        <foreign-key foreignTable="bookstore_employee" onDelete="cascade">
+        <column name="role_id" type="INTEGER" required="false" default="null" outputGroup="public"/>
+        <column name="authenticator" type="VARCHAR" size="32" defaultExpr="'Password'" outputGroup="public"/>
+        <foreign-key foreignTable="bookstore_employee" onDelete="cascade" outputGroup="public,short">
             <reference local="employee_id" foreign="id"/>
         </foreign-key>
-        <foreign-key foreignTable="acct_access_role" onDelete="setnull">
+        <foreign-key foreignTable="acct_access_role" onDelete="setnull" outputGroup="public">
             <reference local="role_id" foreign="id"/>
         </foreign-key>
         <unique>
@@ -189,10 +189,10 @@
     </table>
 
     <table name="acct_audit_log">
-        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true"/>
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" outputGroup="public"/>
         <column name="uid" type="VARCHAR" size="32" required="true"/>
-        <column name="message" type="VARCHAR" size="255"/>
-        <foreign-key foreignTable="bookstore_employee_account" onDelete="cascade">
+        <column name="message" type="VARCHAR" size="255" outputGroup="public,short"/>
+        <foreign-key foreignTable="bookstore_employee_account" onDelete="cascade" refOutputGroup="public">
             <reference local="uid" foreign="login"/>
         </foreign-key>
         <index>

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapOutputGroupTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapOutputGroupTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Builder\Om;
+
+use Map\GeneratedTableMapOutputGroupTestTableTableMap;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCase;
+
+class GeneratedTableMapOutputGroupTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        if (class_exists('GeneratedTableMapOutputGroupTestTable')) {
+            return;
+        }
+        $tableName = 'generated_table_map_output_group_test_table';
+        $fkTableName = 'generated_table_map_output_group_test_foreign_table';
+        $schema = <<<EOF
+<database>
+    <table name="$tableName">
+        <column name="fkGroup1" type="integer" />
+        <column name="fkGroup2" type="integer" />
+        <column name="colGroup1" type="integer" outputGroup="group1"/>
+        <column name="colGroup2" type="integer" outputGroup="group2"/>
+        <column name="nogroupCol" type="integer" />
+        <foreign-key foreignTable="$fkTableName" phpName="LocalFk0" outputGroup="group1">
+            <reference local="fkGroup1" foreign="ft_col0"/>
+        </foreign-key>
+        <foreign-key foreignTable="$fkTableName" phpName="LocalFk1" outputGroup="group1,group2">
+            <reference local="fkGroup2" foreign="ft_col1"/>
+        </foreign-key>
+    </table>
+    <table name="$fkTableName">
+        <column name="ft_col0" type="integer" />
+        <column name="ft_col1" type="integer" />
+        <column name="ft_fkGroup1" type="integer" />
+        <column name="ft_fkGroup2" type="integer" />
+
+        <foreign-key foreignTable="$tableName" phpName="RefFk2" refOutputGroup="group1">
+            <reference local="ft_fkGroup1" foreign="colGroup1"/>
+        </foreign-key>
+        <foreign-key foreignTable="$tableName" phpName="RefFk3" refOutputGroup="group1,group2">
+            <reference local="ft_fkGroup2" foreign="colGroup2"/>
+        </foreign-key>
+    </table>
+</database>
+EOF;
+        QuickBuilder::buildSchema($schema);
+    }
+
+    public function groupDataProvider(): array
+    {
+        return [
+        [
+            'group1', [
+                'column_index' => [2],
+                'relation' => [
+                    'LocalFk0' => 1,
+                    'LocalFk1' => 1,
+                    'GeneratedTableMapOutputGroupTestForeignTableRelatedByFtFkgroup1' => 1,
+                    'GeneratedTableMapOutputGroupTestForeignTableRelatedByFtFkgroup2' => 1,
+                ],
+            ],
+        ], [
+            'group2', [
+                'column_index' => [3],
+                'relation' => [
+                    'LocalFk1' => 1,
+                    'GeneratedTableMapOutputGroupTestForeignTableRelatedByFtFkgroup2' => 1,
+                ],
+            ],
+        ], [
+            'unknown_group', [
+                'column_index' => [0, 1, 2, 3, 4],
+                'relation' => null,
+                ],
+        ]];
+    }
+
+    /**
+     * @dataProvider groupDataProvider
+     *
+     * @return void
+     */
+    public function testGetOutputGroupData(string $groupName, array $expectedGroupData)
+    {
+        $groupData = GeneratedTableMapOutputGroupTestTableTableMap::getOutputGroupData($groupName);
+        $this->assertEquals($expectedGroupData, $groupData);
+    }
+}

--- a/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Formatter;
+
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Tests\Bookstore\AcctAccessRole;
+use Propel\Tests\Bookstore\AcctAuditLog;
+use Propel\Tests\Bookstore\BookstoreEmployee;
+use Propel\Tests\Bookstore\BookstoreEmployeeAccount;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class OutputGroupTest extends BookstoreTestBase
+{
+    public function getPopulatedAccountObject()
+    {
+        $employee = (new BookstoreEmployee())->fromArray([
+            'Id' => 1,
+            'ClassKey' => 1,
+            'Name' => 'le name',
+            'JobTitle' => 'Manger',
+        ]);
+        $account = (new BookstoreEmployeeAccount())->fromArray([
+            'EmployeeId' => 1,
+            'Login' => 'le login',
+            'Password' => 'le password',
+            'Enabled' => true,
+            'NotEnabled' => false,
+            'Created' => '2024-04-18 11:52:13.533707',
+            'RoleId' => 5,
+            'Authenticator' => 'Password',
+        ]);
+        $role = (new AcctAccessRole())->fromArray([
+            'Id' => 5,
+            'Name' => 'le role name',
+        ]);
+        $logs = array_map(fn ($i) => (new AcctAuditLog())->fromArray([
+            'Id' => $i,
+            'Uid' => 1, // fk to account id
+            'Message' => 'le message ' . $i,
+        ]), range(1, 2));
+
+        $account->setAcctAccessRole($role);
+        $account->setBookstoreEmployee($employee);
+        $account->setAcctAuditLogs(new ObjectCollection($logs));
+
+        return $account;
+    }
+
+    public function outputGroupDataProvider()
+    {
+        $accountShort = [
+            'EmployeeId' => 1,
+            'Login' => 'le login',
+        ];
+        $accountPublic = [
+            ...$accountShort,
+            'Created' => '2024-04-18 11:52:13.533707',
+            'RoleId' => 5,
+            'Authenticator' => 'Password',
+        ];
+
+        $employeeShort = [
+            'Id' => 1,
+            'Name' => 'le name',
+        ];
+
+        $employeePublic = [
+            ...$employeeShort,
+            'ClassKey' => 1,
+            'JobTitle' => 'Manger',
+            'SupervisorId' => null,
+            'Photo' => null,
+            'BookstoreEmployeeAccount' => ['*RECURSION*'],
+        ];
+
+        $role = [
+            'Id' => 5,
+            'Name' => 'le role name',
+            'BookstoreEmployeeAccounts' => [['*RECURSION*']],
+        ];
+
+        $logsPublic = [
+            ['Id' => 1, 'Message' => 'le message 1'],
+            ['Id' => 2, 'Message' => 'le message 2'],
+        ];
+        $logsShort = [
+            ['Message' => 'le message 1'],
+            ['Message' => 'le message 2'],
+        ];
+
+        return [
+            [
+                'public',
+                [
+                    ...$accountPublic,
+                    'BookstoreEmployee' => $employeePublic,
+                    'AcctAccessRole' => $role,
+                    'AcctAuditLogs' => $logsPublic,
+                ],
+            ],
+            [
+                'short',
+                [
+                    ...$accountShort,
+                    'BookstoreEmployee' => $employeeShort,
+                ],
+            ],
+            [
+                [
+                    BookstoreEmployeeAccount::class => 'public',
+                    BookstoreEmployee::class => 'public',
+                    'default' => 'short',
+                ],
+                [
+                    ...$accountPublic,
+                    'BookstoreEmployee' => $employeePublic,
+                    'AcctAccessRole' => $role,
+                    'AcctAuditLogs' => $logsShort,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider outputGroupDataProvider
+     *
+     * @return void
+     */
+    public function testNums($outputGroup, array $expected)
+    {
+        $account = $this->getPopulatedAccountObject();
+        $output = $account->toOutputGroup($outputGroup);
+
+        $this->assertEquals($expected, $output);
+    }
+}

--- a/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
@@ -79,7 +79,6 @@ class OutputGroupTest extends BookstoreTestBase
             'JobTitle' => 'Manger',
             'SupervisorId' => null,
             'Photo' => null,
-            'BookstoreEmployeeAccount' => ['*RECURSION*'],
         ];
 
         $role = [

--- a/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OutputGroupTest.php
@@ -84,7 +84,6 @@ class OutputGroupTest extends BookstoreTestBase
         $role = [
             'Id' => 5,
             'Name' => 'le role name',
-            'BookstoreEmployeeAccounts' => [['*RECURSION*']],
         ];
 
         $logsPublic = [

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -10,6 +10,8 @@ namespace Propel\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Propel\Generator\Platform\PlatformInterface;
+use ReflectionClass;
+use ReflectionProperty;
 
 class TestCase extends PHPUnitTestCase
 {
@@ -37,13 +39,13 @@ class TestCase extends PHPUnitTestCase
             $target = $this->getDriver();
         }
 
-        if ('sqlite' === $target && 'mysql' === $source) {
+        if ($target === 'sqlite' && $source === 'mysql') {
             return preg_replace('/`([^`]*)`/', '[$1]', $sql);
         }
-        if ('pgsql' === $target && 'mysql' === $source) {
+        if ($target === 'pgsql' && $source === 'mysql') {
             return preg_replace('/`([^`]*)`/', '"$1"', $sql);
         }
-        if ('mysql' !== $target && 'mysql' === $source) {
+        if ($target !== 'mysql' && $source === 'mysql') {
             return str_replace('`', '', $sql);
         }
 
@@ -124,5 +126,73 @@ class TestCase extends PHPUnitTestCase
         $obj = new $className($con);
 
         return $obj;
+    }
+
+    /**
+     * Run private or preotected method.
+     *
+     * @see https://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit
+     *
+     * @param object $obj Instance with protected or private methods
+     * @param string $name Name of the protected or private method
+     * @param array $args Argumens for method
+     *
+     * @return mixed Result of method call
+     */
+    public function callMethod(object $obj, string $name, array $args = [])
+    {
+        $class = new ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $method->setAccessible(true); // Use this if you are running PHP older than 8.1.0
+        }
+
+        return $method->invokeArgs($obj, $args);
+    }
+
+    /**
+     * Get private or protected property.
+     *
+     * @param object|class-string $obj Instance with protected or private property
+     * @param string $name Name of the protected or private property
+     *
+     * @return void
+     */
+    public function getProperty($obj, string $name): ReflectionProperty
+    {
+        $reflection = new ReflectionClass($obj);
+        $property = $reflection->getProperty($name);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $property->setAccessible(true);
+        }
+
+        return $property;
+    }
+
+    /**
+     * Get private or protected property value.
+     *
+     * @param object|class-string $obj Instance with protected or private property
+     * @param string $name Name of the protected or private property
+     *
+     * @return mixed
+     */
+    public function getValue($obj, string $name)
+    {
+        return $this->getProperty($obj, $name)->getValue();
+    }
+
+    /**
+     * Set private or protected property
+     *
+     * @param object|class-string $obj Instance with protected or private property
+     * @param string $name Name of the protected or private property
+     * @param mixed $value New value for property
+     *
+     * @return void
+     */
+    public function setProperty($obj, string $name, $value): void
+    {
+        $this->getProperty($obj, $name)->setValue($obj, $value);
     }
 }


### PR DESCRIPTION
Allows declaring output groups on columns and foreign key relations in schema.xml. Passing a group name to the `toOutputGroup()` method on the model or ObjectCollection returns an array holding all values defined by the group name.

So in schema.xml:
```xml
<table name="le_table">
  <column name="col1" outputGroup="foo,bar" />
  <column name="col2" />
  <foreign-key phpName="fk" outputGroup="foo">
    ...
```

On an object:
```php
leTableObject->toOutputGroup('foo'); // will return ['Col1' => ..., 'Fk' => ...]
leTableObject->toOutputGroup('bar'); // will return ['Col1' => ...]
```

Instead of a group name, an array with model class names can also be used:
```php
leTableObject->toOutputGroup([
  LeTable::class => 'foo',
  'default' => 'bar'
]);
```

It automatically skips recursive output:

<table>
  <tr>
    <th>toArray</th>
    <th>toOutputGroup</th>
  </tr>
  <tr>
    <td>

```php
[
  'event' => [
    'event_id' => 1,
    'event_type' => [
      'event_type_id' => 1,
      'events' => [[*RECURSION*]]
    ]
  ]
]
```
</td>
    <td>

```php
[
  'event' => [
    'event_id' => 1,
    'event_type' => [
      'event_type_id' => 1,
    ]
  ]
]
```
</td>
  </tr>
</table>


I find this much easier than using a serializer as I don't have to re-iterate all columns in another file.