### PR TITLE
fix test schemas: mysql requires unique index for complex fk

### DIFF
--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -323,6 +323,10 @@
         <foreign-key foreignTable="book" onDelete="setnull" phpName="Work">
             <reference local="prize_book_id" foreign="id"/>
         </foreign-key>
+        <unique>
+            <unique-column name="bookstore_id"/>
+            <unique-column name="contest_id"/>
+        </unique>
     </table>
 
     <table name="bookstore_contest_entry" reloadOnInsert="true">

--- a/tests/Fixtures/schemas/schema.xml
+++ b/tests/Fixtures/schemas/schema.xml
@@ -67,6 +67,10 @@
         <foreign-key foreignTable="bookstore" foreignSchema="bookstore_schemas" onDelete="cascade">
             <reference local="bookstore_id" foreign="id"/>
         </foreign-key>
+        <unique>
+            <unique-column name="bookstore_id"/>
+            <unique-column name="id"/>
+        </unique>
     </table>
 
     <table name="second_hand_book" schema="second_hand_books">


### PR DESCRIPTION
Fixes error when running the test with MySQL 8.4 (latest):
```
In SqlManager.php line 203:
                                                                          
  SQL insert failed: CREATE TABLE `contest`.`bookstore_contest_entry`     
  (                                                                       
      `bookstore_id` INTEGER NOT NULL,                                    
      `contest_id` INTEGER NOT NULL,                                      
      `customer_id` INTEGER NOT NULL,                                     
      `entry_date` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,              
      PRIMARY KEY (`bookstore_id`,`contest_id`,`customer_id`),            
      INDEX `bookstore_contest_entry_fi_6043da` (`customer_id`),          
      CONSTRAINT `bookstore_contest_entry_fk_2e7157`                      
          FOREIGN KEY (`bookstore_id`)                                    
          REFERENCES `bookstore_schemas`.`bookstore` (`id`)               
          ON DELETE CASCADE,                                              
      CONSTRAINT `bookstore_contest_entry_fk_6043da`                      
          FOREIGN KEY (`customer_id`)                                     
          REFERENCES `bookstore_schemas`.`customer` (`id`)                
          ON DELETE CASCADE,                                              
      CONSTRAINT `bookstore_contest_entry_fk_e1b7af`                      
          FOREIGN KEY (`bookstore_id`,`contest_id`)                       
          REFERENCES `contest`.`bookstore_contest` (`bookstore_id`,`id`)  
          ON DELETE CASCADE                                               
  ) ENGINE=InnoDB                                                         
                                                                          

In StatementWrapper.php line 219:
                                                                               
  SQLSTATE[HY000]: General error: 6125 Failed to add the foreign key constrai  
  nt. Missing unique key for constraint 'bookstore_contest_entry_fk_e1b7af' i  
  n the referenced table 'bookstore_contest'                                   
                                                     
```
(see failed run [here](https://github.com/mringler/Propel2/actions/runs/9197204127/job/25297097600?pr=10)) 

The complex FK now requires a unique index on the referenced table. This [blog](https://www.skeema.io/blog/2024/05/14/mysql84-surprises/) has a nice summary of the issue.