### PR TITLE
Feature/storable configuration behavior

### DIFF
--- a/src/Propel/Generator/Behavior/ConfigLoad/ConfigLoadBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigLoad/ConfigLoadBehavior.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Behavior\ConfigLoad;
+
+use Propel\Generator\Behavior\ConfigStore\ConfigOperationBehavior;
+use Propel\Generator\Behavior\ConfigStore\ConfigurationStore;
+use Propel\Generator\Exception\SchemaException;
+
+class ConfigLoadBehavior extends ConfigOperationBehavior
+{
+    /**
+     * @var string
+     */
+    public const ATTRIBUTE_KEY_REF = 'ref';
+
+    /**
+     * @var string
+     */
+    public const ATTRIBUTE_KEY_MULTIPLE = 'multiple';
+
+    /**
+     * @return string
+     */
+    protected function getKey(): string
+    {
+        return $this->getAttribute(static::ATTRIBUTE_KEY_REF);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Database|\Propel\Generator\Model\Table $behaviorable
+     *
+     * @return void
+     */
+    protected function apply($behaviorable): void
+    {
+        $this->validateAttributes();
+        $this->createBehavior($behaviorable);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Database|\Propel\Generator\Model\Table $behaviorable
+     *
+     * @return void
+     */
+    public function createBehavior($behaviorable): void
+    {
+        $configuration = ConfigurationStore::getInstance()->loadPreconfiguration($this->getKey());
+        $fullAttributes = array_merge([], $configuration->getBehaviorAttributes(), $this->getAuxilaryAttributes());
+        $fullParams = array_merge([], $configuration->getParameters(), $this->parameters);
+        $behavior = $behaviorable->addBehavior($fullAttributes);
+        $behavior->setParameters(array_merge($behavior->getParameters(), $fullParams));
+    }
+
+    /**
+     * @return array
+     */
+    protected function getAuxilaryAttributes(): array
+    {
+        $ownAttributes = [
+            static::ATTRIBUTE_KEY_REF => 1,
+            static::ATTRIBUTE_KEY_MULTIPLE => 1,
+            'name' => 1,
+            'id' => 1,
+        ];
+
+        $attributes = array_diff_key($this->attributes, $ownAttributes);
+
+        if ($this->getAttribute(static::ATTRIBUTE_KEY_MULTIPLE, false)) {
+            $attributes['id'] = $this->getKey() . '_' . uniqid();
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return void
+     */
+    protected function validateAttributes(): void
+    {
+        if (!$this->getAttribute(static::ATTRIBUTE_KEY_REF)) {
+            throw new SchemaException(sprintf("%s behavior: required parameter '%s' is missing.", $this->getName(), static::ATTRIBUTE_KEY_REF));
+        }
+    }
+}

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigOperationBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigOperationBehavior.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Behavior\ConfigStore;
+
+use Propel\Generator\Model\Behavior;
+
+abstract class ConfigOperationBehavior extends Behavior
+{
+    /**
+     * Indicates whether the behavior can be applied several times on the same
+     * table or not.
+     *
+     * @return bool
+     */
+    public function allowMultiple(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getKey(): string;
+
+     /**
+      * @return void
+      */
+    public function modifyDatabase(): void
+    {
+        $this->apply($this->database);
+    }
+
+    /**
+     * @return void
+     */
+    public function modifyTable(): void
+    {
+        $this->apply($this->table);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Database|\Propel\Generator\Model\Table $behaviorable
+     *
+     * @return void
+     */
+    abstract protected function apply($behaviorable): void;
+}

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigStoreBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigStoreBehavior.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Behavior\ConfigStore;
+
+use Propel\Generator\Exception\SchemaException;
+
+class ConfigStoreBehavior extends ConfigOperationBehavior
+{
+    /**
+     * Use store instad of load behavior.
+     *
+     * @var string
+     */
+    public const ATTRIBUTE_KEY_BEHAVIOR = 'behavior';
+
+    /**
+     * Make sure behavior is never applied twice.
+     *
+     * @var bool
+     */
+    protected $wasApplied = false;
+
+    /**
+     * Indicates whether the behavior can be applied several times on the same
+     * table or not.
+     *
+     * @return bool
+     */
+    public function allowMultiple(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Database|\Propel\Generator\Model\Table $behaviorable
+     *
+     * @return void
+     */
+    protected function apply($behaviorable): void
+    {
+        if ($this->wasApplied) {
+            return;
+        }
+        $this->wasApplied = true;
+        $this->validateAttributes();
+        $this->storeConfiguration();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getKey(): string
+    {
+        return $this->getAttribute('id');
+    }
+
+    /**
+     * @return void
+     */
+    protected function storeConfiguration(): void
+    {
+        $attributes = $this->getAuxilaryAttributes();
+        $attributes['name'] = $this->getAttribute(static::ATTRIBUTE_KEY_BEHAVIOR);
+        ConfigurationStore::getInstance()->storePreconfiguration($this->getKey(), $attributes, $this->parameters);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getAuxilaryAttributes(): array
+    {
+        $ownAttributes = [
+            static::ATTRIBUTE_KEY_BEHAVIOR => 1,
+            'name' => 1,
+            'id' => 1,
+        ];
+
+        return array_diff_key($this->attributes, $ownAttributes);
+    }
+
+    /**
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return void
+     */
+    protected function validateAttributes(): void
+    {
+        if (!$this->getAttribute(static::ATTRIBUTE_KEY_BEHAVIOR)) {
+            throw new SchemaException(sprintf("%s behavior: required parameter '%s' is missing.", $this->getName(), static::ATTRIBUTE_KEY_BEHAVIOR));
+        }
+
+        if (!$this->getAttribute('id')) {
+            throw new SchemaException(sprintf("%s behavior: required parameter 'id' is missing.", $this->getName()));
+        }
+
+        if (ConfigurationStore::getInstance()->hasPreconfiguration($this->getKey())) {
+            $format = "%s behavior for '%s': key '%s' is already in use.";
+            $message = sprintf($format, $this->getName(), $this->getAttribute(static::ATTRIBUTE_KEY_BEHAVIOR), $this->getKey());
+
+            throw new SchemaException($message);
+        }
+    }
+}

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigurationItem.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigurationItem.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Behavior\ConfigStore;
+
+class ConfigurationItem
+{
+    /**
+     * @var array
+     */
+    protected $behaviorAttributes;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @param array $behaviorAttributes
+     * @param array $parameters
+     */
+    public function __construct(array $behaviorAttributes, array $parameters)
+    {
+        $this->behaviorAttributes = $behaviorAttributes;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getBehaviorAttributes(): array
+    {
+        return $this->behaviorAttributes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigurationStore.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigurationStore.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Behavior\ConfigStore;
+
+use Propel\Generator\Exception\SchemaException;
+
+class ConfigurationStore
+{
+    /**
+     * @var \Propel\Generator\Behavior\ConfigStore\ConfigurationStore|null
+     */
+    protected static $instance = null;
+
+    /**
+     * @var array<\Propel\Generator\Behavior\ConfigStore\ConfigurationItem>
+     */
+    private static $preconfigurations = [];
+
+    /**
+     * @return \Propel\Generator\Behavior\ConfigStore\ConfigurationStore|self
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * @param string $key
+     * @param array<string> $behaviorAttributes
+     * @param array<string> $params
+     *
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return void
+     */
+    public function storePreconfiguration(string $key, array $behaviorAttributes, array $params): void
+    {
+        if ($this->hasPreconfiguration($key)) {
+            throw new SchemaException("preconfigure behavior: $key '%s' is already in use.");
+        }
+
+        self::$preconfigurations[$key] = new ConfigurationItem($behaviorAttributes, $params);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return \Propel\Generator\Behavior\ConfigStore\ConfigurationItem
+     */
+    public function loadPreconfiguration(string $key): ConfigurationItem
+    {
+        if (!array_key_exists($key, self::$preconfigurations)) {
+            throw new SchemaException("preconfigure behavior: No preconfigured behavior with key '$key'.");
+        }
+
+        return self::$preconfigurations[$key];
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function hasPreconfiguration(string $key): bool
+    {
+        return array_key_exists($key, self::$preconfigurations);
+    }
+}

--- a/tests/Propel/Tests/Generator/Behavior/ConfigStore/ConfigOperationBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConfigStore/ConfigOperationBehaviorTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ *	$Id$
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Behavior\ConfigStore;
+
+use Propel\Generator\Behavior\AutoAddPk\AutoAddPkBehavior;
+use Propel\Generator\Behavior\ConfigStore\ConfigurationItem;
+use Propel\Generator\Behavior\ConfigStore\ConfigurationStore;
+use Propel\Generator\Exception\SchemaException;
+use Propel\Generator\Model\Database;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCase;
+
+/**
+ */
+class ConfigOperationBehaviorTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        $this->setStoredConfigurations();
+    }
+
+    /**
+     * @return void
+     */
+    public function testStoreConfiguration(): void
+    {
+        $schemaXml = <<<EOT
+        <database>
+            <behavior name="config_store" behavior="foo" id="foo_conf" additional="any">
+                <parameter name="param1" value="value1"/>
+            </behavior>
+        </database>
+EOT;
+        $this->buildSchemaXml($schemaXml);
+
+        $expected = [
+            'foo_conf' => new ConfigurationItem(
+                ['name' => 'foo', 'additional' => 'any'],
+                ['param1' => 'value1']
+            )
+        ];
+        $preconfigurations = $this->getStoredConfigurations();
+
+        $this->assertEquals($expected, $preconfigurations);
+    }
+
+    /**
+     * @return void
+     */
+    public function testLoadBehavior(): void
+    {
+        $schemaXml = <<<EOT
+        <database>
+            <behavior
+                name="config_store"
+                behavior="auto_add_pk"
+                id="le_auto_add"
+                store_attribute="storeAttribute value"
+                override_attribute="inital attribute value"
+            >
+                <parameter name="param1" value="value1"/>
+                <parameter name="override parameter" value="inital parameter value"/>
+            </behavior>
+            <table name="table">
+                <behavior
+                    name="config_load"
+                    ref="le_auto_add"
+                    id="id1"
+                    load_attribute="loadAttribute value"
+                    override_attribute="overridden attribute value"
+                >
+                    <parameter name="param2" value="value2"/>
+                    <parameter name="override parameter" value="overridden parameter value"/>
+                </behavior>
+            </table>
+        </database>
+EOT;
+        $table = $this->buildSchemaXml($schemaXml)->getTable('table');
+        $behavior = $table->getBehavior('auto_add_pk');
+        $this->assertNotNull($behavior, 'Should have created behavior');
+
+        $expectedAttributes = [
+            'name' => 'auto_add_pk',
+            'store_attribute' => 'storeAttribute value',
+            'load_attribute' => 'loadAttribute value',
+            'override_attribute' => 'overridden attribute value'
+        ];
+        $this->assertEqualsCanonicalizing($expectedAttributes, $behavior->getAttributes(), 'Behavior should inherit attributes');
+
+        $expectedParameters = array_merge(
+            (new AutoAddPkBehavior())->getParameters(), // default parameters
+            [
+                'param1' => 'value1',
+                'param2' => 'value2',
+                'override parameter' => 'overridden parameter value',
+            ]
+        );
+        $this->assertEqualsCanonicalizing($expectedParameters, $behavior->getParameters(), 'Behavior should inherit parameters');
+
+        $this->assertNotNull($table->getColumn('id'), 'Should have applied behavior');
+    }
+
+    /**
+     * @return void
+     */
+    public function testStoreCannotOmitId(): void
+    {
+        $schemaXml = <<<EOT
+        <database>
+            <behavior name="config_store" behavior="foo"/>
+        </database>
+EOT;
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessage('config_store behavior: required parameter \'id\' is missing.');
+        $this->buildSchemaXml($schemaXml);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCannotStoreSameRefTwice(): void
+    {
+        $schemaXml = <<<EOT
+        <database>
+            <behavior name="config_store" behavior="foo" id="foo1"/>
+            <table name="table">
+                <behavior name="config_store" behavior="foo" id="foo1"/>
+            </table>
+        </database>
+EOT;
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessage('config_store behavior for \'foo\': key \'foo1\' is already in use.');
+        $this->buildSchemaXml($schemaXml);
+    }
+
+    /**
+     * @return void
+     */
+    public function testLoadMultipleBehaviors(): void
+    {
+        $aggregateParams = '
+        <parameter name="name" value="agg_col" />
+        <parameter name="foreign_table" value="table" />
+        ';
+        $schemaXml = <<<EOT
+        <database>
+            <behavior name="config_store" behavior="aggregate_column" id="aggregate1">$aggregateParams</behavior>
+            <behavior name="config_store" behavior="aggregate_column" id="aggregate2">$aggregateParams</behavior>
+            <table name="table">
+                <behavior name="config_load" ref="aggregate1" id="b1" multiple="1" />
+                <behavior name="config_load" ref="aggregate1" id="b2" multiple="1" />
+                <behavior name="config_load" ref="aggregate2" id="b3" multiple="1" />
+            </table>
+        </database>
+EOT;
+        $database = $this->buildSchemaXml($schemaXml);
+        $behaviors = $database->getTable('table')->getBehaviors();
+        $loadedBehaviors = array_filter($behaviors, fn($key) => preg_match('/^aggregate[12]_[0-9a-f]{13}$/', $key), ARRAY_FILTER_USE_KEY);
+        $this->assertCount(3, $loadedBehaviors);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getStoredConfigurations(): array
+    {
+        $class = new \ReflectionClass(ConfigurationStore::class);
+
+        return $class->getStaticPropertyValue('preconfigurations');
+    }
+
+    /**
+     * @param array
+     * 
+     * @return void
+     */
+    protected function setStoredConfigurations(array $configurations = []): void
+    {
+        $class = new \ReflectionClass(ConfigurationStore::class);
+
+        $class->setStaticPropertyValue('preconfigurations', $configurations);
+    }
+
+    /**
+     * @param string $schemaXml
+     * 
+     * @return Database
+     */
+    public function buildSchemaXml(string $schemaXml): Database
+    {
+        $builder = new QuickBuilder();
+        $builder->setSchema($schemaXml);
+
+        return $builder->getDatabase();
+    }
+}


### PR DESCRIPTION
Adds a behavior that stores the configuration of another behavior:
```xml
<behavior
  name="config_store"
  behavior="archivable"
  id="my_archivable"
>
  <parameter name="log_archived_at" value="true" />
  <parameter name="archived_at_column" value="archival_date" />
  <parameter name="inherit_foreign_key_relations" value="true" />
  <parameter name="inherit_foreign_key_constraints" value="true" />
</behavior>
``` 
The stored behavior can be loaded onto individual tables:
```xml
<table name="my_table">
  <behavior
     name="config_load"
     ref="my_archivable"
  >
     <parameter name="inherit_foreign_key_constraints" value="false" />
  </behavior>
```
The loaded configuration can be amended or overridden as shown above.