### PR TITLE
replace php type boolean with bool

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -6684,7 +6684,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param ConnectionInterface \$con";
         if ($reloadOnUpdate || $reloadOnInsert) {
             $script .= "
-     * @param boolean \$skipReload Whether to skip the reload for this object from database.";
+     * @param bool \$skipReload Whether to skip the reload for this object from database.";
         }
         $script .= "
      * @return int The number of rows affected by this insert/update and any referring fk objects' save() operations.

--- a/src/Propel/Generator/Model/Domain.php
+++ b/src/Propel/Generator/Model/Domain.php
@@ -336,7 +336,7 @@ class Domain extends MappingModel
             throw new EngineException('Cannot get PHP version of default value for default value EXPRESSION.');
         }
 
-        if (in_array($this->mappingType, [PropelTypes::BOOLEAN, PropelTypes::BOOLEAN_EMU], true)) {
+        if (in_array($this->mappingType, [PropelTypes::BOOLEAN, PropelTypes::BOOLEAN_EMU, PropelTypes::BOOLEAN_NATIVE_TYPE], true)) {
             return $this->booleanValue($this->defaultValue->getValue());
         }
 

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -304,12 +304,12 @@ class PropelTypes
     /**
      * @var string
      */
-    public const BOOLEAN_NATIVE_TYPE = 'boolean';
+    public const BOOLEAN_NATIVE_TYPE = 'bool';
 
     /**
      * @var string
      */
-    public const BOOLEAN_EMU_NATIVE_TYPE = 'boolean';
+    public const BOOLEAN_EMU_NATIVE_TYPE = 'bool';
 
     /**
      * @var string
@@ -660,7 +660,7 @@ class PropelTypes
      */
     public static function isPhpPrimitiveType(string $phpType): bool
     {
-        return in_array($phpType, ['boolean', 'int', 'double', 'float', 'string'], true);
+        return in_array($phpType, ['bool', 'boolean', 'int', 'double', 'float', 'string'], true);
     }
 
     /**
@@ -672,7 +672,7 @@ class PropelTypes
      */
     public static function isPhpPrimitiveNumericType(string $phpType): bool
     {
-        return in_array($phpType, ['boolean', 'int', 'double', 'float'], true);
+        return in_array($phpType, ['bool', 'boolean', 'int', 'double', 'float'], true);
     }
 
     /**

--- a/templates/Behavior/Validate/objectAttributes.php
+++ b/templates/Behavior/Validate/objectAttributes.php
@@ -2,7 +2,7 @@
 /**
  * Flag to prevent endless validation loop, if this object is referenced
  * by another object which falls in this transaction.
- * @var        boolean
+ * @var        bool
  */
 protected $alreadyInValidation = false;
 

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -655,7 +655,7 @@ class ColumnTest extends ModelTestCase
         $column->setDomain($domain);
         $column->setType($mappingType);
 
-        $this->assertSame('boolean', $column->getPhpType());
+        $this->assertSame('bool', $column->getPhpType());
         $this->assertTrue($column->isPhpPrimitiveType());
         $this->assertTrue($column->isBooleanType());
     }


### PR DESCRIPTION
Some doctypes are generated with PHP type `boolean`:
```
 * @method     ChildUser[]|Collection findByIsDeleted(boolean|array<boolean> $is_deleted) Return ChildUser objects filtered by the is_deleted column
``` 
But it should be `bool`.