### PR TITLE
Extract column replacement out of (Model)Criteria

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -11,6 +11,7 @@ namespace Propel\Runtime\ActiveQuery;
 use ArrayIterator;
 use IteratorAggregate;
 use Propel\Runtime\ActiveQuery\Exception\UnknownModelException;
+use Propel\Runtime\ActiveQuery\Util\ColumnResolver;
 use Propel\Runtime\Exception\InvalidArgumentException;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Formatter\AbstractFormatter;
@@ -67,6 +68,11 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     protected $defaultFormatterClass = ModelCriteria::FORMAT_OBJECT;
 
     /**
+     * @var \Propel\Runtime\ActiveQuery\Util\ColumnResolver
+     */
+    protected $columnResolver;
+
+    /**
      * Creates a new instance with the default capacity which corresponds to
      * the specified database.
      *
@@ -79,6 +85,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
         parent::__construct($dbName);
         $this->setModelName($modelName);
         $this->modelAlias = $modelAlias;
+        $this->columnResolver = new ColumnResolver($this);
     }
 
     /**
@@ -360,5 +367,21 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
         }
 
         throw new LogicException('The current formatter doesn\'t return an iterable result');
+    }
+
+    /**
+     * @param string $tableName
+     *
+     * @return \Propel\Runtime\ActiveQuery\ModelJoin|null
+     */
+    public function getModelJoinByTableName(string $tableName): ?ModelJoin
+    {
+        foreach ($this->joins as $join) {
+            if ($join instanceof ModelJoin && $join->getTableMapOrFail()->getName() == $tableName) {
+                return $join;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -390,23 +390,6 @@ class Criteria
     protected $identifierQuoting = false;
 
     /**
-     * @var array
-     */
-    public $replacedColumns = [];
-
-    /**
-     * temporary property used in replaceNames
-     *
-     * @var string|null
-     */
-    protected $currentAlias;
-
-    /**
-     * @var bool
-     */
-    protected $foundMatch = false;
-
-    /**
      * Creates a new instance with the default capacity which corresponds to
      * the specified database.
      *
@@ -2193,72 +2176,27 @@ class Criteria
     }
 
     /**
-     * Replaces complete column names (like Article.AuthorId) in an SQL clause
-     * by their exact Propel column fully qualified name (e.g. article.author_id)
-     * but ignores the column names inside quotes
-     * e.g. 'CONCAT(Book.AuthorID, "Book.AuthorID") = ?'
-     *   => 'CONCAT(book.author_id, "Book.AuthorID") = ?'
+     * Default implementation.
      *
-     * @param string $sql SQL clause to inspect (modified by the method)
+     * @param string $sql
      *
-     * @return bool Whether the method managed to find and replace at least one column name
+     * @return bool
      */
     public function replaceNames(string &$sql): bool
     {
-        $this->replacedColumns = [];
-        $this->currentAlias = '';
-        $this->foundMatch = false;
-        $isAfterBackslash = false;
-        $isInString = false;
-        $stringQuotes = '';
-        $parsedString = '';
-        $stringToTransform = '';
-        $len = strlen($sql);
-        $pos = 0;
-        while ($pos < $len) {
-            $char = $sql[$pos];
-            // check flags for strings or escaper
-            switch ($char) {
-                case '\\':
-                    $isAfterBackslash = true;
+        return false;
+    }
 
-                    break;
-                case "'":
-                case '"':
-                    if ($isInString && $stringQuotes == $char) {
-                        if (!$isAfterBackslash) {
-                            $isInString = false;
-                        }
-                    } elseif (!$isInString) {
-                        $parsedString .= preg_replace_callback("/[\w\\\]+\.\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
-                        $stringToTransform = '';
-                        $stringQuotes = $char;
-                        $isInString = true;
-                    }
-
-                    break;
-            }
-
-            if ($char !== '\\') {
-                $isAfterBackslash = false;
-            }
-
-            if ($isInString) {
-                $parsedString .= $char;
-            } else {
-                $stringToTransform .= $char;
-            }
-
-            $pos++;
-        }
-
-        if ($stringToTransform) {
-            $parsedString .= preg_replace_callback("/[\w\\\]+\.\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
-        }
-
-        $sql = $parsedString;
-
-        return $this->foundMatch;
+    /**
+     * Default implementation.
+     *
+     * @param string $sql
+     *
+     * @return string
+     */
+    public function replaceColumnNames(string $sql): string
+    {
+        return $sql;
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -25,7 +25,6 @@ use Propel\Runtime\ActiveQuery\Criterion\RawCriterion;
 use Propel\Runtime\ActiveQuery\Criterion\RawModelCriterion;
 use Propel\Runtime\ActiveQuery\Criterion\SeveralModelCriterion;
 use Propel\Runtime\ActiveQuery\Exception\UnknownColumnException;
-use Propel\Runtime\ActiveQuery\Exception\UnknownModelException;
 use Propel\Runtime\ActiveQuery\Exception\UnknownRelationException;
 use Propel\Runtime\ActiveQuery\ModelCriteria as ActiveQueryModelCriteria;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -348,15 +347,15 @@ class ModelCriteria extends BaseModelCriteria
      */
     public function orderBy(string $columnName, string $order = Criteria::ASC)
     {
-        [, $realColumnName] = $this->getColumnFromName($columnName, false);
+        $localColumnName = $this->columnResolver->resolveColumn($columnName, false)->getLocalColumnName();
         $order = strtoupper($order);
         switch ($order) {
             case Criteria::ASC:
-                $this->addAscendingOrderByColumn($realColumnName);
+                $this->addAscendingOrderByColumn($localColumnName);
 
                 break;
             case Criteria::DESC:
-                $this->addDescendingOrderByColumn($realColumnName);
+                $this->addDescendingOrderByColumn($localColumnName);
 
                 break;
             default:
@@ -378,25 +377,25 @@ class ModelCriteria extends BaseModelCriteria
      *    => $c->addGroupByColumn(BookTableMap::AUTHOR_ID)
      *    => $c->addGroupByColumn(BookTableMap::AUTHOR_NAME)
      *
-     * @param mixed $columnName an array of columns name (e.g. array('Book.AuthorId', 'Book.AuthorName')) or a single column name (e.g. 'Book.AuthorId')
+     * @param mixed $columnNames an array of columns name (e.g. array('Book.AuthorId', 'Book.AuthorName')) or a single column name (e.g. 'Book.AuthorId')
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
      * @return $this The current object, for fluid interface
      */
-    public function groupBy($columnName)
+    public function groupBy($columnNames)
     {
-        if (!$columnName) {
+        if (!$columnNames) {
             throw new PropelException('You must ask for at least one column');
         }
 
-        if (!is_array($columnName)) {
-            $columnName = [$columnName];
+        if (!is_array($columnNames)) {
+            $columnNames = [$columnNames];
         }
 
-        foreach ($columnName as $column) {
-            [, $realColumnName] = $this->getColumnFromName($column, false);
-            $this->addGroupByColumn($realColumnName);
+        foreach ($columnNames as $columnName) {
+            $localColumnName = $this->columnResolver->resolveColumn($columnName, false)->getLocalColumnName();
+            $this->addGroupByColumn($localColumnName);
         }
 
         return $this;
@@ -854,8 +853,7 @@ class ModelCriteria extends BaseModelCriteria
             $name = str_replace(['.', '(', ')'], '', $clause);
         }
 
-        $clause = trim($clause);
-        $this->replaceNames($clause);
+        $clause = $this->columnResolver->replaceColumnNames(trim($clause));
         // check that the columns of the main class are already added (if this is the primary ModelCriteria)
         if (!$this->hasSelectClause() && !$this->getPrimaryCriteria()) {
             $this->addSelfSelectColumns();
@@ -2125,44 +2123,44 @@ class ModelCriteria extends BaseModelCriteria
      */
     protected function getCriterionForClause(string $clause, $value, ?int $bindingType = null): AbstractCriterion
     {
-        $origin = $clause = trim($clause);
-        if ($this->replaceNames($clause)) {
+        $resolvedColumn = $this->columnResolver->resolveFirstColumn($clause);
+
+        if ($resolvedColumn) {
             // at least one column name was found and replaced in the clause
             // this is enough to determine the type to bind the parameter to
-            /** @var \Propel\Runtime\Map\ColumnMap $colMap */
-            $colMap = $this->replacedColumns[0];
-            $value = $this->convertValueForColumn($value, $colMap);
+
+            $value = $this->convertValueForColumn($value, $resolvedColumn->getColumnMap());
             $clauseLen = strlen($clause);
             if ($bindingType !== null) {
-                return new RawModelCriterion($this, $clause, $colMap, $value, $this->currentAlias, $bindingType);
+                return new RawModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias(), $bindingType);
             }
             if (stripos($clause, 'IN ?') == $clauseLen - 4) {
-                if ($colMap->isSetType()) {
+                if ($resolvedColumn->getColumnMap()->isSetType()) {
                     if (stripos($clause, 'NOT IN ?') == $clauseLen - 8) {
                         $clause = str_ireplace('NOT IN ?', '& ? = 0', $clause);
                     } else {
                         $clause = str_ireplace('IN ?', '& ?', $clause);
                     }
                 } else {
-                    return new InModelCriterion($this, $clause, $colMap, $value, $this->currentAlias);
+                    return new InModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias());
                 }
             }
             if (stripos($clause, '& ?') !== false) {
-                return new BinaryModelCriterion($this, $clause, $colMap, $value, $this->currentAlias);
+                return new BinaryModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias());
             }
             if (stripos($clause, 'LIKE ?') == $clauseLen - 6) {
-                return new LikeModelCriterion($this, $clause, $colMap, $value, $this->currentAlias);
+                return new LikeModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias());
             }
             if (substr_count($clause, '?') > 1) {
-                return new SeveralModelCriterion($this, $clause, $colMap, $value, $this->currentAlias);
+                return new SeveralModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias());
             }
 
-            return new BasicModelCriterion($this, $clause, $colMap, $value, $this->currentAlias);
+            return new BasicModelCriterion($this, $clause, $resolvedColumn->getColumnMap(), $value, $resolvedColumn->getTableAlias());
         }
         // no column match in clause, must be an expression like '1=1'
         if (strpos($clause, '?') !== false) {
             if ($bindingType === null) {
-                throw new PropelException(sprintf('Cannot determine the column to bind to the parameter in clause "%s".', $origin));
+                throw new PropelException(sprintf('Cannot determine the column to bind to the parameter in clause "%s".', trim($clause)));
             }
 
             return new RawCriterion($this, $clause, $value, $bindingType);
@@ -2205,130 +2203,40 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
-     * Callback function to replace column names by their real name in a clause
-     * e.g. 'Book.Title IN ?'
-     *    => 'book.title IN ?'
-     *
-     * @param array $matches Matches found by preg_replace_callback
-     *
-     * @return string the column name replacement
-     */
-    protected function doReplaceNameInExpression(array $matches): string
-    {
-        $key = $matches[0];
-        [$column, $realFullColumnName] = $this->getColumnFromName($key);
-
-        if (!$column instanceof ColumnMap) {
-            return $this->quoteIdentifier($key);
-        }
-
-        $this->replacedColumns[] = $column;
-        $this->foundMatch = true;
-
-        if (strpos($key, '.') !== false) {
-            [$tableName, $columnName] = explode('.', $key);
-            if (isset($this->aliases[$tableName])) {
-                //don't replace a alias with their real table name
-                $realColumnName = substr($realFullColumnName, strrpos($realFullColumnName, '.') + 1);
-
-                return $this->quoteIdentifier($tableName . '.' . $realColumnName);
-            }
-        }
-
-        return $this->quoteIdentifier($realFullColumnName);
-    }
-
-    /**
-     * Finds a column and a SQL translation for a pseudo SQL column name
-     * Respects table aliases previously registered in a join() or addAlias()
-     * Examples:
-     * <code>
-     * $c->getColumnFromName('Book.Title');
-     *   => array($bookTitleColumnMap, 'book.title')
-     * $c->join('Book.Author a')
-     *   ->getColumnFromName('a.FirstName');
-     *   => array($authorFirstNameColumnMap, 'a.first_name')
-     * </code>
+     * @deprecated Use ColumnResolver::resolveColumn()
      *
      * @param string $columnName String representing the column name in a pseudo SQL clause, e.g. 'Book.Title'
      * @param bool $failSilently
      *
-     * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownColumnException
-     * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownModelException
-     *
-     * @return array List($columnMap, $realColumnName)
+     * @return array List($columnMap, $localColumnName)
      */
-    protected function getColumnFromName(string $columnName, bool $failSilently = true): array
+    public function getColumnFromName(string $columnName, bool $failSilently = true): array
     {
-        if (strpos($columnName, '.') === false) {
-            $prefix = (string)$this->getModelAliasOrName();
-        } else {
-            // $prefix could be either class name or table name
-            [$prefix, $columnName] = explode('.', $columnName);
-        }
+        $resolvedColumn = $this->columnResolver->resolveColumn($columnName, $failSilently);
 
-        $shortClass = static::getShortName($prefix);
-
-        if ($prefix === $this->getModelAliasOrName()) {
-            // column of the Criteria's model
-            $tableMap = $this->getTableMap();
-        } elseif ($prefix === $this->getModelShortName()) {
-            // column of the Criteria's model
-            $tableMap = $this->getTableMap();
-        } elseif ($this->getTableMap() && $prefix == $this->getTableMap()->getName()) {
-            // column name from Criteria's tableMap
-            $tableMap = $this->getTableMap();
-        } elseif (isset($this->joins[$prefix])) {
-            // column of a relations's model
-            $tableMap = $this->joins[$prefix]->getTableMap();
-        } elseif (isset($this->joins[$shortClass])) {
-            // column of a relations's model
-            $tableMap = $this->joins[$shortClass]->getTableMap();
-        } elseif ($this->hasSelectQuery($prefix)) {
-            return $this->getColumnFromSubQuery($prefix, $columnName, $failSilently);
-        } elseif ($this->getModelJoinByTableName($prefix)) {
-            $tableMap = $this->getModelJoinByTableName($prefix)->getTableMap();
-        } elseif ($failSilently) {
-            return [null, null];
-        } else {
-            throw new UnknownModelException(sprintf('Unknown model, alias or table "%s"', $prefix));
-        }
-
-        $column = $tableMap->findColumnByName($columnName);
-
-        if ($column !== null) {
-            if (isset($this->aliases[$prefix])) {
-                $this->currentAlias = $prefix;
-                $realColumnName = $prefix . '.' . $column->getName();
-            } else {
-                $realColumnName = $column->getFullyQualifiedName();
-            }
-
-            return [$column, $realColumnName];
-        } elseif (isset($this->asColumns[$columnName])) {
-            // aliased column
-            return [null, $columnName];
-        } elseif ($failSilently) {
-            return [null, null];
-        } else {
-            throw new UnknownColumnException(sprintf('Unknown column "%s" on model, alias or table "%s"', $columnName, $prefix));
-        }
+        return [$resolvedColumn->getColumnMap(), $resolvedColumn->getLocalColumnName()];
     }
 
     /**
-     * @param string $tableName
+     * @deprecated use ModelCriteria::replaceColumnNames()
      *
-     * @return \Propel\Runtime\ActiveQuery\ModelJoin|null
+     * @param string $sql
+     *
+     * @return bool
      */
-    public function getModelJoinByTableName(string $tableName): ?ModelJoin
+    public function replaceNames(string &$sql): bool
     {
-        foreach ($this->joins as $join) {
-            if ($join instanceof ModelJoin && $join->getTableMapOrFail()->getName() == $tableName) {
-                return $join;
-            }
-        }
+        return $this->columnResolver->replaceColumnNamesAndReturnIndicator($sql);
+    }
 
-        return null;
+    /**
+     * @param string $sql
+     *
+     * @return string
+     */
+    public function replaceColumnNames(string $sql): string
+    {
+        return $this->columnResolver->replaceColumnNames($sql);
     }
 
     /**
@@ -2387,46 +2295,13 @@ class ModelCriteria extends BaseModelCriteria
             if (array_key_exists($columnName, $this->asColumns)) {
                 continue;
             }
-            [$columnMap, $realColumnName] = $this->getColumnFromName($columnName);
-            if ($realColumnName === null) {
+            $localColumnName = $this->columnResolver->resolveColumn($columnName)->getLocalColumnName();
+            if ($localColumnName === null) {
                 throw new PropelException("Cannot find selected column '$columnName'");
             }
             // always put quotes around the columnName to be safe, we strip them in the formatter
-            $this->addAsColumn('"' . $columnName . '"', $realColumnName);
+            $this->addAsColumn('"' . $columnName . '"', $localColumnName);
         }
-    }
-
-    /**
-     * Special case for subquery columns
-     *
-     * @param string $class
-     * @param string $phpName
-     * @param bool $failSilently
-     *
-     * @throws \Propel\Runtime\Exception\PropelException
-     *
-     * @return array List($columnMap, $realColumnName)
-     */
-    protected function getColumnFromSubQuery(string $class, string $phpName, bool $failSilently = true): array
-    {
-        $subQueryCriteria = $this->getSelectQuery($class);
-        $tableMap = $subQueryCriteria->getTableMap();
-        if ($tableMap->hasColumnByPhpName($phpName)) {
-            $column = $tableMap->getColumnByPhpName($phpName);
-            $realColumnName = $class . '.' . $column->getName();
-            $this->currentAlias = $class;
-
-            return [null, $realColumnName];
-        }
-        if (isset($subQueryCriteria->asColumns[$phpName])) {
-            // aliased column
-            return [null, $class . '.' . $phpName];
-        }
-        if ($failSilently) {
-            return [null, null];
-        }
-
-        throw new PropelException(sprintf('Unknown column "%s" in the subQuery with alias "%s".', $phpName, $class));
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
@@ -135,8 +135,7 @@ abstract class AbstractSqlQueryBuilder
     {
         $criterionSql = '';
         $criterion->appendPsTo($criterionSql, $params);
-        $this->criteria->replaceNames($criterionSql);
 
-        return $criterionSql;
+        return $this->criteria->replaceColumnNames($criterionSql);
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -62,8 +62,7 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
 
         $groupBy = $this->adapter->getGroupBy($this->criteria);
         if ($groupBy) {
-            $this->criteria->replaceNames($groupBy);
-            $sqlClauses[] = $groupBy;
+            $sqlClauses[] = $this->criteria->replaceColumnNames($groupBy);
         }
 
         $havingSql = $this->buildHavingClause($params);
@@ -99,9 +98,8 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
     protected function buildSelectClause(array &$sourceTableNamesCollector): string
     {
         $selectSql = $this->adapter->createSelectSqlPart($this->criteria, $sourceTableNamesCollector);
-        $this->criteria->replaceNames($selectSql);
 
-        return $selectSql;
+        return $this->criteria->replaceColumnNames($selectSql);
     }
 
     /**
@@ -190,8 +188,7 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
             }
             $join->setAdapter($this->adapter);
             $joinClauseString = $join->getClause($params);
-            $this->criteria->replaceNames($joinClauseString);
-            $joinClause[] = $joinClauseString;
+            $joinClause[] = $this->criteria->replaceColumnNames($joinClauseString);
         }
 
         return $joinClause;
@@ -328,12 +325,10 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
             $column = ($tableName) ? $this->dbMap->getTable($tableName)->getColumn($columnName) : null;
             if ($this->criteria->isIgnoreCase() && $column && $column->isText()) {
                 $ignoreCaseColumn = $this->adapter->ignoreCaseInOrderBy("$tableAlias.$columnAlias");
-                $this->criteria->replaceNames($ignoreCaseColumn);
-                $orderByClause[] = $ignoreCaseColumn . $direction;
+                $orderByClause[] = $this->criteria->replaceColumnNames($ignoreCaseColumn) . $direction;
                 $additionalSelectStatements[] = ', ' . $ignoreCaseColumn;
             } else {
-                $this->criteria->replaceNames($orderByColumn);
-                $orderByClause[] = $orderByColumn;
+                $orderByClause[] = $this->criteria->replaceColumnNames($orderByColumn);
             }
         }
 

--- a/src/Propel/Runtime/ActiveQuery/Util/ColumnResolver.php
+++ b/src/Propel/Runtime/ActiveQuery/Util/ColumnResolver.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Propel\Runtime\ActiveQuery\Util;
+
+use Propel\Runtime\ActiveQuery\BaseModelCriteria;
+use Propel\Runtime\ActiveQuery\Exception\UnknownColumnException;
+use Propel\Runtime\ActiveQuery\Exception\UnknownModelException;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveQuery\ModelJoin;
+use Propel\Runtime\Exception\PropelException;
+
+class ColumnResolver
+{
+    /**
+     * @var \Propel\Runtime\ActiveQuery\BaseModelCriteria
+     */
+    protected $query;
+
+    /**
+     * ColumnMap for columns found in statement
+     *
+     * @var array<\Propel\Runtime\ActiveQuery\Util\ResolvedColumn>
+     */
+    private $replacedColumns = [];
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\BaseModelCriteria $query
+     */
+    public function __construct(BaseModelCriteria $query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * Retrieve the first column found in SQL clause.
+     *
+     * Used when creating Criterions from clauses.
+     *
+     * @param string $clause
+     *
+     * @return \Propel\Runtime\ActiveQuery\Util\ResolvedColumn|null
+     */
+    public function resolveFirstColumn(string $clause): ?ResolvedColumn
+    {
+        $this->replaceColumnNames($clause);
+
+        return $this->replacedColumns[0] ?? null;
+    }
+
+    /**
+     * @deprecated old version of ColumnResolver::replaceColumnNames().
+     *
+     * @param string $sql SQL clause to inspect (modified by the method)
+     *
+     * @return bool Whether the method managed to find and replace at least one column name
+     */
+    public function replaceColumnNamesAndReturnIndicator(string &$sql): bool
+    {
+        $sql = $this->replaceColumnNames($sql);
+
+        return count($this->replacedColumns) > 0;
+    }
+
+     /**
+      * Replaces complete column names (like Article.AuthorId) in an SQL clause
+      * by their exact Propel column fully qualified name (e.g. article.author_id).
+      *
+      * Ignores column names inside quotes.
+      *
+      * <code>
+      * 'CONCAT(Book.AuthorID, "Book.AuthorID") = ?'
+      *   => 'CONCAT(book.author_id, "Book.AuthorID") = ?'
+      * </code>
+      *
+      * @param string $sql SQL clause to inspect
+      *
+      * @return string modified statement
+      */
+    public function replaceColumnNames(string $sql): string
+    {
+        $this->replacedColumns = [];
+
+        $parsedString = ''; // collects the result
+        $stringToTransform = ''; // collects substrings from input to be processed before written to result
+        $len = strlen($sql);
+        $pos = 0;
+        // go through string, write text in quotes to output, rest is written after transform
+        while ($pos < $len) {
+            $char = $sql[$pos];
+
+            if (($char !== "'" && $char !== '"') || ($pos > 0 && $sql[$pos - 1] === '\\')) {
+                $stringToTransform .= $char;
+            } else {
+                // start of quote, process what was found so far
+                $parsedString .= preg_replace_callback("/[\w\\\]+\.\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
+                $stringToTransform = '';
+
+                // copy to result until end of quote
+                $openingQuoteChar = $char;
+                $parsedString .= $char;
+                while (++$pos < $len) {
+                    $char = $sql[$pos];
+                    $parsedString .= $char;
+                    if ($char === $openingQuoteChar && $sql[$pos - 1] !== '\\') {
+                        break;
+                    }
+                }
+            }
+            $pos++;
+        }
+
+        if ($stringToTransform) {
+            $parsedString .= preg_replace_callback("/[\w\\\]+\.\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
+        }
+
+        return $parsedString;
+    }
+
+    /**
+     * Callback function to replace column names by their real name in a clause
+     * e.g. 'Book.Title IN ?'
+     *    => 'book.title IN ?'
+     *
+     * @param array $matches Matches found by preg_replace_callback
+     *
+     * @return string the column name replacement
+     */
+    protected function doReplaceNameInExpression(array $matches): string
+    {
+        $key = $matches[0];
+        $resolvedColumn = $this->resolveColumn($key);
+
+        if (!$resolvedColumn->isFromLocalTable()) {
+            return $this->query->quoteIdentifier($key);
+        }
+
+        $this->replacedColumns[] = $resolvedColumn;
+
+        return $this->query->quoteIdentifier($resolvedColumn->getLocalColumnName());
+    }
+
+    /**
+     * Finds a column and a SQL translation for a pseudo SQL column name.
+     *
+     * Examples:
+     * <code>
+     * $c->resolveColumn('Book.Title');
+     *   => new ResolvedColumn('book.title', $bookTitleColumnMap)
+     *
+     * $c->join('Book.Author a')->resolveColumn('a.FirstName');
+     *   => new ResolvedColumn('a.first_name', $authorFirstNameColumnMap)
+     * </code>
+     *
+     * @param string $columnName String representing the column name in a pseudo SQL clause, e.g. 'Book.Title'
+     * @param bool $failSilently
+     *
+     * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownColumnException
+     * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownModelException
+     *
+     * @return \Propel\Runtime\ActiveQuery\Util\ResolvedColumn
+     */
+    public function resolveColumn(string $columnName, bool $failSilently = true): ResolvedColumn
+    {
+        if (strpos($columnName, '.') === false) {
+            $prefix = (string)$this->query->getModelAliasOrName();
+        } else {
+            // $prefix could be either class name or table name
+            [$prefix, $columnName] = explode('.', $columnName);
+        }
+
+        $query = $this->query;
+        $shortClassName = BaseModelCriteria::getShortName($prefix);
+
+        if (
+            $prefix === $query->getModelAliasOrName()
+            || $prefix === $query->getModelShortName()
+            || ($query->getTableMap() && $prefix === $query->getTableMap()->getName())
+        ) {
+            // column name from Criteria's table
+            $tableMap = $query->getTableMap();
+        } elseif ($query->hasJoin($prefix) || $query->hasJoin($shortClassName)) {
+            // column of a relations's model
+            $tableIdentifier = $query->hasJoin($prefix) ? $prefix : $shortClassName;
+            $join = $query->getJoin($tableIdentifier);
+            if (!($join instanceof ModelJoin)) {
+                return new ResolvedColumn("$tableIdentifier.$columnName", null, $tableIdentifier);
+            }
+            $tableMap = $join->getTableMap();
+        } elseif ($query->hasSelectQuery($prefix)) {
+            return $this->getColumnFromSubQuery($prefix, $columnName, $failSilently);
+        } elseif ($query->getModelJoinByTableName($prefix)) {
+            $tableMap = $query->getModelJoinByTableName($prefix)->getTableMap();
+        } elseif ($failSilently) {
+            return ResolvedColumn::getEmptyResolvedColumn();
+        } else {
+            throw new UnknownModelException(sprintf('Unknown model, alias or table "%s"', $prefix));
+        }
+
+        $column = $tableMap->findColumnByName($columnName);
+
+        if ($column !== null) {
+            if ($query->getTableForAlias($prefix)) {
+                $tableAlias = $prefix;
+                $localColumnName = $prefix . '.' . $column->getName();
+            } else {
+                $tableAlias = null;
+                $localColumnName = $column->getFullyQualifiedName();
+            }
+
+            return new ResolvedColumn($localColumnName, $column, $tableAlias);
+        } elseif ($query->getColumnForAs($columnName)) {
+            // local column
+            return new ResolvedColumn($columnName);
+        } elseif ($failSilently) {
+            return ResolvedColumn::getEmptyResolvedColumn();
+        } else {
+            throw new UnknownColumnException(sprintf('Unknown column "%s" on model, alias or table "%s"', $columnName, $prefix));
+        }
+    }
+
+    /**
+     * Special case for subquery columns
+     *
+     * @param string $prefix
+     * @param string $columnPhpName
+     * @param bool $failSilently
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return \Propel\Runtime\ActiveQuery\Util\ResolvedColumn
+     */
+    protected function getColumnFromSubQuery(string $prefix, string $columnPhpName, bool $failSilently = true): ResolvedColumn
+    {
+        $subQueryCriteria = $this->query->getSelectQuery($prefix);
+        $tableMap = $subQueryCriteria instanceof ModelCriteria ? $subQueryCriteria->getTableMap() : null;
+        if ($tableMap && $tableMap->hasColumnByPhpName($columnPhpName)) {
+            $column = $tableMap->getColumnByPhpName($columnPhpName);
+            $localColumnName = $prefix . '.' . $column->getName();
+
+            return new ResolvedColumn($localColumnName, null, $prefix);
+        }
+        if ($subQueryCriteria->getColumnForAs($columnPhpName) !== null) {
+            // aliased column
+            return new ResolvedColumn("$prefix.$columnPhpName");
+        }
+        if ($failSilently) {
+            return ResolvedColumn::getEmptyResolvedColumn();
+        }
+
+        throw new PropelException(sprintf('Unknown column "%s" in the subQuery with alias "%s".', $columnPhpName, $prefix));
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/Util/ResolvedColumn.php
+++ b/src/Propel/Runtime/ActiveQuery/Util/ResolvedColumn.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Propel\Runtime\ActiveQuery\Util;
+
+use Propel\Runtime\Map\ColumnMap;
+
+class ResolvedColumn
+{
+ /**
+  * @var \Propel\Runtime\Map\ColumnMap|null
+  */
+    protected $columnMap;
+
+    /**
+     * @var string|null
+     */
+    protected $localColumnName;
+
+    /**
+     * @var string|null
+     */
+    protected $tableAlias;
+
+    /**
+     * @param string $localColumnName
+     * @param \Propel\Runtime\Map\ColumnMap|null $columnMap
+     * @param string|null $tableAlias
+     */
+    public function __construct(string $localColumnName, ?ColumnMap $columnMap = null, ?string $tableAlias = null)
+    {
+        $this->columnMap = $columnMap;
+        $this->localColumnName = $localColumnName;
+        $this->tableAlias = $tableAlias;
+    }
+
+    /**
+     * Creates an empty ResolvedColumn.
+     *
+     * Used when a column cannot be found but no error message is expected.
+     *
+     * @return \Propel\Runtime\ActiveQuery\Util\ResolvedColumn
+     */
+    public static function getEmptyResolvedColumn()
+    {
+        $result = new self('');
+        $result->localColumnName = null;
+
+        return $result;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLocalColumnName(): ?string
+    {
+        return $this->localColumnName;
+    }
+
+    /**
+     * @return \Propel\Runtime\Map\ColumnMap|null
+     */
+    public function getColumnMap(): ?ColumnMap
+    {
+        return $this->columnMap;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTableAlias(): ?string
+    {
+        return $this->tableAlias;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFromLocalTable(): bool
+    {
+        return $this->columnMap !== null;
+    }
+}


### PR DESCRIPTION
Clean up column resolve in Model(Criteria).

Mostly extracts these methods into a new utility class:
- `Criteria::replaceNames()`: normalizes column name literals in strings AND extracts column map for found columns
- `ModelCriteria::doReplaceNameInExpression()`: preg callback used in Criteria::replaceNames() (!)
- `ModelCriteria::getColumnFromName()`: find column map for a column string.
- `ModelCriteria::getColumnFromSubQuery()`: utility function used in ModelCriteria::getColumnFromName()

Original has issues with inheritance, where parent class (Criteria) uses properties and calls methods only available on child class (ModelCriteria). Also, Criteria had class attributes to transfer data from a callback (`replacedColumns`, `currentAlias`, `foundMatch`) back to caller.

Class attributes were removed except `replacedColumns`, which is still needed in tests (aka me too lazy to handle now).

The big confusion around `Criteria::replaceNames()` was that it does two separate things:
 - `ModelCriteria::getCriterionForClause()` used the method to retrieve column maps from clause expressions.
 - Query building (among others) uses the method to normalize column names. 

While the function still perform both actions (again, lazy), it is now separated into different calls making the distinction apparent.