### PR TITLE
switch ci to ubuntu 24.04 and minor fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     testsuite:
         name: "Test Suite"
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         strategy:
             fail-fast: false
             matrix:
@@ -138,7 +138,7 @@ jobs:
                   file: tests/coverage.xml
 
     code-style-and-static-analysis:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Setup PHP
               id: setup-php

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -59,7 +59,7 @@ abstract class BookstoreTestBase extends TestCaseFixturesDatabase
         // and we don't want to call ConnectionInterface::commit() in that case
         // since it will trigger an exception on its own
         // ('Cannot commit because a nested transaction was rolled back')
-        if (null !== $this->con) {
+        if ($this->con !== null) {
             if ($this->con->isCommitable()) {
                 $this->con->commit();
             }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1280,15 +1280,6 @@ class CriteriaTest extends BookstoreTestBase
                 'limit' => '9223372036854775807',
                 'expected' => 9223372036854775807,
             ],
-
-            'Decimal value' => [
-                'limit' => 123.9,
-                'expected' => 123,
-            ],
-            'Decimal value as a string' => [
-                'limit' => '123.9',
-                'expected' => 123,
-            ],
         ];
     }
 
@@ -1352,15 +1343,6 @@ class CriteriaTest extends BookstoreTestBase
             'Largest 64-bit integer as a string' => [
                 'offset' => '9223372036854775807',
                 'expected' => 9223372036854775807,
-            ],
-
-            'Decimal value' => [
-                'offset' => 123.9,
-                'expected' => 123,
-            ],
-            'Decimal value as a string' => [
-                'offset' => '123.9',
-                'expected' => 123,
             ],
         ];
     }

--- a/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
@@ -41,7 +41,6 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
     {
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $book = $c->findOne($con);
-        $count = $con->getQueryCount();
         $this->assertEquals($book['Title'], 'Don Juan', 'Main object is correctly hydrated ' . $msg);
         $author = $book['Author'];
         $this->assertEquals($author['LastName'], 'Byron', 'Related object is correctly hydrated ' . $msg);


### PR DESCRIPTION
sqlite tests are failing for no apparent reason 
> PDOException: SQLSTATE[HY000]: General error: 5 database is locked

(see failed job [here](https://github.com/mringler/Propel2/actions/runs/13856140809/job/38773291017))

Might be an issue with the sqlite version? Updating to more recent Ubuntu version can't hurt either way.