### PR TITLE
externalize deprecated Criteria interface

### DIFF
--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -340,7 +340,7 @@ protected \$delegatedFields = [
  * @param mixed \$value A value for the condition
  * @param string \$comparison What to use for the column comparison, defaults to Criteria::EQUAL and Criteria::IN for queries
  *
- * @return \$this The current object, for fluid interface
+ * @return \$this
  */
 public function filterBy(string \$column, \$value, string \$comparison = null)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -95,11 +95,11 @@ class NestedSetBehaviorObjectBuilderModifier
         $script = "if (\$this->isNew() && \$this->isRoot()) {
     // check if no other root exist in, the tree
     \$rootExists = $queryClassName::create()
-        ->addUsingAlias($objectClassName::LEFT_COL, 1, Criteria::EQUAL)";
+        ->addUsingOperator($objectClassName::LEFT_COL, 1, Criteria::EQUAL)";
 
         if ($this->behavior->useScope()) {
             $script .= "
-        ->addUsingAlias($objectClassName::SCOPE_COL, \$this->getScopeValue(), Criteria::EQUAL)";
+        ->addUsingOperator($objectClassName::SCOPE_COL, \$this->getScopeValue(), Criteria::EQUAL)";
         }
 
         $script .= "

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -641,7 +641,7 @@ public function hasParent(): bool
  * Use moveTofirstChildOf() or moveToLastChildOf() for that purpose
  *
  * @param $objectClassName \$parent
- * @return \$this The current object, for fluid interface
+ * @return \$this
  */
 public function setParent($objectClassName \$parent = null)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
@@ -154,7 +154,7 @@ class NestedSetBehaviorQueryBuilderModifier
 /**
  * Filter the query to restrict the result to root objects
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function treeRoots()
 {
@@ -178,7 +178,7 @@ public function treeRoots()
  *
  * @param int|null \$scope Scope to determine which objects node to return
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function inTree(?int \$scope = null)
 {
@@ -203,7 +203,7 @@ public function inTree(?int \$scope = null)
  *
  * @param {$this->objectClassName} $objectName The object to use for descendant search
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function descendantsOf($this->objectClassName $objectName)
 {
@@ -236,7 +236,7 @@ public function descendantsOf($this->objectClassName $objectName)
  *
  * @param {$this->objectClassName} $objectName The object to use for branch search
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function branchOf($this->objectClassName $objectName)
 {
@@ -268,7 +268,7 @@ public function branchOf($this->objectClassName $objectName)
  *
  * @param {$this->objectClassName} $objectName The object to use for child search
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function childrenOf($this->objectClassName $objectName)
 {
@@ -297,7 +297,7 @@ public function childrenOf($this->objectClassName $objectName)
  * @param {$this->objectClassName} $objectName The object to use for sibling search
  * @param ConnectionInterface \$con Connection to use.
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function siblingsOf($this->objectClassName $objectName, ?ConnectionInterface \$con = null)
 {
@@ -329,7 +329,7 @@ public function siblingsOf($this->objectClassName $objectName, ?ConnectionInterf
  *
  * @param {$this->objectClassName} $objectName The object to use for ancestors search
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function ancestorsOf($this->objectClassName $objectName)
 {
@@ -362,7 +362,7 @@ public function ancestorsOf($this->objectClassName $objectName)
  *
  * @param {$this->objectClassName} $objectName The object to use for roots search
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function rootsOf($this->objectClassName $objectName)
 {
@@ -393,7 +393,7 @@ public function rootsOf($this->objectClassName $objectName)
  *
  * @param bool \$reverse if true, reverses the order
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function orderByBranch(\$reverse = false)
 {
@@ -423,7 +423,7 @@ public function orderByBranch(\$reverse = false)
  *
  * @param bool \$reverse if true, reverses the order
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function orderByLevel(\$reverse = false)
 {

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -454,7 +454,7 @@ protected function makeSlugUnique(string \$slug, string \$separator = '" . $this
  *
  * @param string \$slug The value to use as filter.
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function filterBySlug(string \$slug)
 {

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -448,6 +448,7 @@ protected function makeSlugUnique(string \$slug, string \$separator = '" . $this
      */
     protected function addFilterBySlug(string &$script): void
     {
+        $slugColumnName = $this->getColumnForParameter('slug_column')->getName();
         $script .= "
 /**
  * Filter the query on the slug column
@@ -458,7 +459,7 @@ protected function makeSlugUnique(string \$slug, string \$separator = '" . $this
  */
 public function filterBySlug(string \$slug)
 {
-    \$this->addUsingAlias(" . $this->builder->getColumnConstant($this->getColumnForParameter('slug_column')) . ", \$slug, Criteria::EQUAL);
+    \$this->addUsingOperator(\$this->resolveLocalColumnByName('{$slugColumnName}'), \$slug, Criteria::EQUAL);
 
     return \$this;
 }

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -192,7 +192,7 @@ static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
  *
 $paramsDoc
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function inList($methodSignature)
 {
@@ -228,7 +228,7 @@ $paramsDoc
         }
         $script .= "
  *
- * @return static The current object, for fluid interface
+ * @return static
  */
 public function filterByRank(\$rank" . ($useScope ? ", $methodSignature" : '') . ")
 {";
@@ -263,7 +263,7 @@ public function filterByRank(\$rank" . ($useScope ? ", $methodSignature" : '') .
  *
  * @param string \$order either Criteria::ASC (default) or Criteria::DESC
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function orderByRank(string \$order = Criteria::ASC)
 {

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -156,7 +156,7 @@ class SortableBehaviorQueryBuilderModifier
  *
  * @return void
  */
-static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, string \$method = 'add'): void
+static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, string \$method = 'addFilter'): void
 {
 ";
         if ($this->behavior->hasMultipleScopes()) {
@@ -197,7 +197,7 @@ $paramsDoc
 public function inList($methodSignature)
 {
     $buildScope
-    static::sortableApplyScopeCriteria(\$this, \$scope, 'addUsingAlias');
+    static::sortableApplyScopeCriteria(\$this, \$scope, 'addUsingOperator');
 
     return \$this;
 }

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -191,7 +191,7 @@ public function keepUpdateDateUnchanged()
  *
  * @param int \$nbDays Maximum age of the latest update in days
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function recentlyUpdated(\$nbDays = 7)
 {
@@ -203,7 +203,7 @@ public function recentlyUpdated(\$nbDays = 7)
 /**
  * Order by update date desc
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function lastUpdatedFirst()
 {
@@ -215,7 +215,7 @@ public function lastUpdatedFirst()
 /**
  * Order by update date asc
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function firstUpdatedFirst()
 {
@@ -232,7 +232,7 @@ public function firstUpdatedFirst()
 /**
  * Order by create date desc
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function lastCreatedFirst()
 {
@@ -246,7 +246,7 @@ public function lastCreatedFirst()
  *
  * @param int \$nbDays Maximum age of in days
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function recentlyCreated(\$nbDays = 7)
 {
@@ -258,7 +258,7 @@ public function recentlyCreated(\$nbDays = 7)
 /**
  * Order by create date asc
  *
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function firstCreatedFirst()
 {

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -185,6 +185,7 @@ public function keepUpdateDateUnchanged()
 
         if ($this->withUpdatedAt()) {
             $updateColumnConstant = $this->getColumnConstant('update_column', $builder);
+            $columnName = $this->getColumnForParameter('update_column')->getName();
             $script .= "
 /**
  * Filter by the latest updated
@@ -195,7 +196,7 @@ public function keepUpdateDateUnchanged()
  */
 public function recentlyUpdated(\$nbDays = 7)
 {
-    \$this->addUsingAlias($updateColumnConstant, time() - \$nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
+    \$this->addUsingOperator(\$this->resolveLocalColumnByName('{$columnName}'), time() - \$nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
 
     return \$this;
 }
@@ -228,6 +229,7 @@ public function firstUpdatedFirst()
 
         if ($this->withCreatedAt()) {
             $createColumnConstant = $this->getColumnConstant('create_column', $builder);
+            $columnName = $this->getColumnForParameter('create_column')->getName();
             $script .= "
 /**
  * Order by create date desc
@@ -246,13 +248,11 @@ public function lastCreatedFirst()
  *
  * @param int \$nbDays Maximum age of in days
  *
- * @return \$this
+ * @return static
  */
 public function recentlyCreated(\$nbDays = 7)
 {
-    \$this->addUsingAlias($createColumnConstant, time() - \$nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
-
-    return \$this;
+    return \$this->addUsingOperator(\$this->resolveLocalColumnByName('{$columnName}'), time() - \$nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
 }
 
 /**

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
@@ -172,7 +172,7 @@ static \$isVersioningEnabled = true;
  *
  * @param int|null \$version
  * @param string|null  \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function filterByVersion(\$version = null, ?string \$comparison = null)
 {
@@ -195,7 +195,7 @@ public function filterByVersion(\$version = null, ?string \$comparison = null)
  * Wrap the order on the version column
  *
  * @param string \$order The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
- * @return \$this The current query, for fluid interface
+ * @return \$this
  */
 public function orderByVersion(string \$order = Criteria::ASC)
 {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3399,7 +3399,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param string \$data The source data to import from
      * @param string \$keyType The type of keys the array uses.
      *
-     * @return \$this The current object, for fluid interface
+     * @return \$this
      */
     public function importFrom(\$parser, string \$data, string \$keyType = TableMap::$defaultKeyType)
     {

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -877,7 +877,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @param mixed \$key Primary key to use for the query
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterByPrimaryKey(\$key)
     {";
@@ -941,7 +941,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @param array|int \$keys The list of primary key to use for the query
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterByPrimaryKeys(\$keys)
     {";
@@ -1086,7 +1086,7 @@ class QueryBuilder extends AbstractOMBuilder
         $script .= "
      * @param string|null \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy$colPhpName(\$$variableName = null, ?string \$comparison = null)
     {
@@ -1228,7 +1228,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param mixed \$$variableName The value to use as filter
      * @param string|null \$comparison Operator to use for the column comparison, defaults to Criteria::CONTAINS_ALL
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy$singularPhpName(\$$variableName = null, ?string \$comparison = null)
     {
@@ -1273,7 +1273,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param mixed \$$variableName The value to use as filter
      * @param string \$comparison Operator to use for the column comparison, defaults to Criteria::CONTAINS_ALL
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy$singularPhpName(\$$variableName = null, ?string \$comparison = null)
     {
@@ -1321,7 +1321,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @throws \\Propel\\Runtime\\Exception\\PropelException
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy$relationName($objectName, ?string \$comparison = null)
     {
@@ -1397,7 +1397,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param $fkPhpName|ObjectCollection $objectName the related object to use as filter
      * @param string|null \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy$relationName($objectName, ?string \$comparison = null)
     {
@@ -1506,7 +1506,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param string|null \$relationAlias Optional alias for the relation
      * @param string|null \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function join" . $relationName . '(?string $relationAlias = null, ?string $joinType = ' . $joinType . ")
     {
@@ -1749,7 +1749,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param $fkPhpName $objectName the related object to use as filter
      * @param string \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL and Criteria::IN for queries
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function filterBy{$relName}($objectName, string \$comparison = null)
     {
@@ -1783,7 +1783,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @param $class $objectName Object to remove from the list of results
      *
-     * @return \$this The current query, for fluid interface
+     * @return \$this
      */
     public function prune($objectName = null)
     {

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -973,7 +973,7 @@ class QueryBuilder extends AbstractOMBuilder
             // composite primary key
             $script .= "
         if (empty(\$keys)) {
-            \$this->add(null, '1<>1', Criteria::CUSTOM);
+            \$this->addFilter(null, '1<>1', Criteria::CUSTOM);
 
             return \$this;
         }

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -107,7 +107,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @param array $with
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function setWith(array $with)
     {
@@ -128,7 +128,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @throws \Propel\Runtime\Exception\InvalidArgumentException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function setFormatter($formatter)
     {
@@ -197,7 +197,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownModelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function setModelName(?string $modelName)
     {
@@ -240,7 +240,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      * @param string $modelAlias The model alias
      * @param bool $useAliasInSQL Whether to use the alias in the SQL code (false by default)
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function setModelAlias(string $modelAlias, bool $useAliasInSQL = false)
     {

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/LocalColumnExpression.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/LocalColumnExpression.php
@@ -79,4 +79,11 @@ class LocalColumnExpression extends AbstractColumnExpression
             'value' => $value,
         ];
     }
+
+    /**
+     * @return void
+     */
+    public function resolveTableAlias(): void
+    {
+    }
 }

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2486,10 +2486,10 @@ class Criteria
     public function __call(string $name, array $arguments)
     {
         if (
-            in_array($name, ['getMap', 'keys', 'containsKey', 'keyContainsValue', 'getCriterion', 'getLastCriterion', 'getTablesColumns', 'getTablesColumns', 'getTableName',
-            'get', 'put', 'putAll', 'addCond', 'hasCond', 'getCond', 'combine', 'getCriterionForConditions', 'addSelectQuery', 'remove', 'size', 'getNamedCriterions',
-            'getCriterionForCondition', 'quoteIdentifier', 'replaceNames', 'getPrimaryKey', 'getComparison',
-
+            in_array($name, [
+                'getMap', 'keys', 'containsKey', 'keyContainsValue', 'getCriterion', 'getLastCriterion', 'getTablesColumns', 'getTablesColumns', 'getTableName',
+                'get', 'put', 'putAll', 'addCond', 'hasCond', 'getCond', 'combine', 'getCriterionForConditions', 'addSelectQuery', 'remove', 'size', 'getNamedCriterions',
+                'getCriterionForCondition', 'quoteIdentifier', 'replaceNames', 'getPrimaryKey', 'getComparison',
             ], true)
         ) {
             trigger_deprecation('Propel', '2.0', "Method $name should not be used anymore, see DeprecatedCriteriaMethods::$name how to replace it.");

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -255,11 +255,6 @@ class Criteria
     protected $ignoreCase = false;
 
     /**
-     * @var bool
-     */
-    protected $singleRecord = false;
-
-    /**
      * Columns used in SELECT
      *
      * @var array<string|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression>
@@ -385,11 +380,6 @@ class Criteria
     protected $aliases = [];
 
     /**
-     * @var bool
-     */
-    protected $useTransaction = false;
-
-    /**
      * Default operator for combination of criterions
      *
      * @see addUsingOperator()
@@ -471,7 +461,6 @@ class Criteria
         $this->filterCollector->clear();
         $this->updateValues->clear();
         $this->ignoreCase = false;
-        $this->singleRecord = false;
         $this->selectModifiers = [];
         $this->lock = null;
         $this->selectColumns = [];
@@ -485,7 +474,6 @@ class Criteria
         $this->offset = 0;
         $this->limit = -1;
         $this->aliases = [];
-        $this->useTransaction = false;
         if ($this->deprecatedMethods) {
             $this->deprecatedMethods->clear();
         }
@@ -632,34 +620,6 @@ class Criteria
     public function hasWhereClause(): bool
     {
         return !$this->filterCollector->isEmpty();
-    }
-
-    /**
-     * Will force the sql represented by this criteria to be executed within
-     * a transaction. This is here primarily to support the oid type in
-     * postgresql. Though it can be used to require any single sql statement
-     * to use a transaction.
-     *
-     * @param bool $v
-     *
-     * @return $this
-     */
-    public function setUseTransaction(bool $v)
-    {
-        $this->useTransaction = $v;
-
-        return $this;
-    }
-
-    /**
-     * Whether the sql command specified by this criteria must be wrapped
-     * in a transaction.
-     *
-     * @return bool
-     */
-    public function isUseTransaction(): bool
-    {
-        return $this->useTransaction;
     }
 
     /**
@@ -1373,36 +1333,6 @@ class Criteria
     }
 
     /**
-     * Set single record? Set this to <code>true</code> if you expect the query
-     * to result in only a single result record (the default behaviour is to
-     * throw a PropelException if multiple records are returned when the query
-     * is executed). This should be used in situations where returning multiple
-     * rows would indicate an error of some sort. If your query might return
-     * multiple records but you are only interested in the first one then you
-     * should be using setLimit(1).
-     *
-     * @param bool $b Set to TRUE if you expect the query to select just one record.
-     *
-     * @return $this Modified Criteria object (for fluent API)
-     */
-    public function setSingleRecord(bool $b)
-    {
-        $this->singleRecord = $b;
-
-        return $this;
-    }
-
-    /**
-     * Is single record?
-     *
-     * @return bool True if a single record is being returned.
-     */
-    public function isSingleRecord(): bool
-    {
-        return $this->singleRecord;
-    }
-
-    /**
      * Set limit.
      *
      * @param int $limit An int with the value for limit.
@@ -1738,7 +1668,6 @@ class Criteria
             $this->offset !== $criteria->getOffset()
             || $this->limit !== $criteria->getLimit()
             || $this->ignoreCase !== $criteria->isIgnoreCase()
-            || $this->singleRecord !== $criteria->isSingleRecord()
             || $this->dbName !== $criteria->getDbName()
             || $this->selectModifiers !== $criteria->getSelectModifiers()
             || $this->getSelectColumns() !== $criteria->getSelectColumns()
@@ -2487,9 +2416,13 @@ class Criteria
     {
         if (
             in_array($name, [
-                'getMap', 'keys', 'containsKey', 'keyContainsValue', 'getCriterion', 'getLastCriterion', 'getTablesColumns', 'getTablesColumns', 'getTableName',
-                'get', 'put', 'putAll', 'addCond', 'hasCond', 'getCond', 'combine', 'getCriterionForConditions', 'addSelectQuery', 'remove', 'size', 'getNamedCriterions',
-                'getCriterionForCondition', 'quoteIdentifier', 'replaceNames', 'getPrimaryKey', 'getComparison',
+                'getMap', 'keys', 'containsKey', 'keyContainsValue', 'getCriterion',
+                'getLastCriterion', 'getTablesColumns', 'getTablesColumns', 'getTableName',
+                'get', 'put', 'putAll', 'addCond', 'hasCond', 'getCond', 'combine',
+                'getCriterionForConditions', 'addSelectQuery', 'remove', 'size',
+                'getNamedCriterions', 'getCriterionForCondition', 'quoteIdentifier',
+                'replaceNames', 'getPrimaryKey', 'getComparison', 'setUseTransaction',
+                'isUseTransaction', 'setSingleRecord', 'isSingleRecord',
             ], true)
         ) {
             trigger_deprecation('Propel', '2.0', "Method $name should not be used anymore, see DeprecatedCriteriaMethods::$name how to replace it.");

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2411,7 +2411,9 @@ class Criteria
                 'getNamedCriterions', 'getCriterionForCondition', 'quoteIdentifier',
                 'replaceNames', 'getPrimaryKey', 'getComparison', 'setUseTransaction',
                 'isUseTransaction', 'setSingleRecord', 'isSingleRecord', 'condition',
-                'getCriterionForClause',
+                'getCriterionForClause', 'isWithOneToMany', 'convertValueForColumn',
+                'getColumnFromName', 'getColumnMapByColumnName', 'getRealColumnName',
+                'getParams', 'buildBindParams', 'addUsingAlias',
             ], true)
         ) {
             trigger_deprecation('Propel', '2.0', "Method $name should not be used anymore, see DeprecatedCriteriaMethods::$name how to replace it.");

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1109,6 +1109,17 @@ class Criteria
     }
 
     /**
+     * Adds a DISTINCT clause to the query
+     * Alias for Criteria::setDistinct()
+     *
+     * @return static
+     */
+    public function distinct()
+    {
+        return $this->setDistinct();
+    }
+
+    /**
      * Adds a modifier to the SQL statement.
      * e.g. self::ALL, self::DISTINCT, 'SQL_CALC_FOUND_ROWS', 'HIGH_PRIORITY', etc.
      *
@@ -1261,6 +1272,19 @@ class Criteria
     }
 
     /**
+     * Adds a LIMIT clause (or its subselect equivalent) to the query
+     * Alias for Criteria::setLimit()
+     *
+     * @param string|int $limit Maximum number of results to return by the query
+     *
+     * @return static
+     */
+    public function limit($limit)
+    {
+        return $this->setLimit((int)$limit);
+    }
+
+    /**
      * Get limit.
      *
      * @return int An int with the value for limit.
@@ -1282,6 +1306,19 @@ class Criteria
         $this->offset = $offset;
 
         return $this;
+    }
+
+    /**
+     * Adds an OFFSET clause (or its subselect equivalent) to the query
+     * Alias for of Criteria::setOffset()
+     *
+     * @param string|int $offset Offset of the first result to return
+     *
+     * @return static
+     */
+    public function offset($offset)
+    {
+        return $this->setOffset((int)$offset);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -309,6 +309,43 @@ class DeprecatedCriteriaMethods extends Criteria
     }
 
     /**
+     * Adds a condition on a column based on a pseudo SQL clause
+     * but keeps it for later use with combine()
+     * Until combine() is called, the condition is not added to the query
+     * Uses introspection to translate the column phpName into a fully qualified name
+     * <code>
+     * $c->condition('cond1', 'b.Title = ?', 'foo');
+     * </code>
+     *
+     * @param string $conditionName A name to store the condition for a later combination with combine()
+     * @param string $clause The pseudo SQL clause, e.g. 'AuthorId = ?'
+     * @param mixed $value A value for the condition
+     * @param mixed $bindingType A value for the condition
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria
+     */
+    public function condition(string $conditionName, string $clause, $value = null, $bindingType = null)
+    {
+        $this->addCond($conditionName, $this->criteria->buildFilterForClause($clause, $value, $bindingType), null, $bindingType);
+
+        return $this->criteria;
+    }
+
+    /**
+     * @deprecated use aptly named {@see static::buildFilterForClause()}
+     *
+     * @param string $clause The pseudo SQL clause, e.g. 'AuthorId = ?'
+     * @param mixed $value A value for the condition
+     * @param int|null $bindingType
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface a Criterion object
+     */
+    public function getCriterionForClause(string $clause, $value, ?int $bindingType = null): ColumnFilterInterface
+    {
+        return $this->buildFilterForClause($clause, $value, $bindingType);
+    }
+
+    /**
      * @param string $name
      *
      * @return bool
@@ -412,7 +449,7 @@ class DeprecatedCriteriaMethods extends Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface
      */
-    protected function getCriterionForCondition(
+    public function getCriterionForCondition(
         $columnOrClause,
         $value = null,
         $comparison = null,
@@ -487,7 +524,7 @@ class DeprecatedCriteriaMethods extends Criteria
         }
         // Assume all the keys are for the same table.
         $key = $this->criteria->updateValues->getColumnExpressionsInQuery()[0];
-        $table = $criteria->getTableName($key);
+        $table = $criteria->getDeprecatedMethods()->getTableName($key);
 
         $pk = null;
 
@@ -525,7 +562,7 @@ class DeprecatedCriteriaMethods extends Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface A Criterion or ModelCriterion object
      */
-    protected function getCriterionForConditions(array $conditions, ?string $operator = null): ColumnFilterInterface
+    public function getCriterionForConditions(array $conditions, ?string $operator = null): ColumnFilterInterface
     {
         $operator = ($operator === null) ? Criteria::LOGICAL_AND : $operator;
         $this->combine($conditions, $operator, 'propel_temp_name');

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -1,0 +1,527 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery;
+
+use LogicException;
+use Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface;
+use Propel\Runtime\Map\ColumnMap;
+use Propel\Runtime\Propel;
+
+class DeprecatedCriteriaMethods extends Criteria
+{
+    /**
+     * @var \Propel\Runtime\ActiveQuery\Criteria
+     */
+    protected $criteria;
+
+    /**
+     * Storage for Criterions expected to be combined
+     *
+     * @var array<string, \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
+     */
+    protected $namedCriterions = [];
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     */
+    public function __construct(Criteria $criteria)
+    {
+        $this->criteria = $criteria;
+    }
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     *
+     * @return void
+     */
+    public function setCriteria(Criteria $criteria): void
+    {
+        $this->criteria = $criteria;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNamedCriterions(): array
+    {
+        return $this->namedCriterions;
+    }
+
+    /**
+     * @return \Propel\Runtime\ActiveQuery\Criteria
+     */
+    public function clear()
+    {
+        $this->namedCriterions = [];
+
+        return $this->criteria;
+    }
+
+    /**
+     * Ensures deep cloning of attached objects
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->namedCriterions = array_map(fn ($c) => clone $c, $this->namedCriterions);
+    }
+
+    /**
+     * @deprecated use aptly named {@see static::getColumnFilters()}.
+     *
+     * @return array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
+     */
+    public function getMap(): array
+    {
+        return $this->criteria->filterCollector->getColumnFiltersByColumn();
+    }
+
+    /**
+     * @deprecated if needed, resolve manually from filterColumns or updateValues.
+     *
+     * Get the keys of the criteria map, i.e. the list of columns bearing a condition
+     * <code>
+     * print_r($c->keys());
+     *  => array('book.price', 'book.title', 'author.first_name')
+     * </code>
+     *
+     * @return array
+     */
+    public function keys(): array
+    {
+        return array_merge(
+            $this->criteria->updateValues->getColumnExpressionsInQuery(),
+            $this->criteria->filterCollector->getColumnExpressionsInQuery(),
+        );
+    }
+
+    /**
+     * @deprecated use {@see Criteria::hasUpdateValue()}
+     *
+     * Does this Criteria object contain the specified key?
+     *
+     * @param string $column [table.]column
+     *
+     * @return bool True if this Criteria object contain the specified key.
+     */
+    public function containsKey(string $column): bool
+    {
+        return $this->criteria->hasUpdateValue($column);
+    }
+
+    /**
+     * @deprecated use {@see static::getUpdateValue()} and check against null yourself.
+     *
+     * @param string $columnName [table.]column
+     *
+     * @return bool True if this Criteria object contain the specified key and a value for that key
+     */
+    public function keyContainsValue(string $columnName): bool
+    {
+        return $this->criteria->getUpdateValue($columnName) !== null;
+    }
+
+    /**
+     * @deprecated use {@see static::findFilterByColumn()} or {@see static::getUpdateValueForColumn()}
+     * Method to return criteria related to columns in a table.
+     *
+     * Make sure you call containsKey($column) prior to calling this method,
+     * since no check on the existence of the $column is made in this method.
+     *
+     * @param string $column Column name.
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface A Criterion object.
+     */
+    public function getCriterion(string $column): ColumnFilterInterface
+    {
+        return $this->criteria->findFilterByColumn($column);
+    }
+
+    /**
+     * @deprecated use aptly named {@see static::getLastFilter()}
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|null A Criterion or null no Criterion is added.
+     */
+    public function getLastCriterion(): ?ColumnFilterInterface
+    {
+        return $this->criteria->getLastFilter();
+    }
+
+    /**
+     * @deprecated use {@see static::getUpdateValuesByTable()} or {@see static::getFiltersByTable()}.
+     *
+     * Shortcut method to get an array of columns indexed by table.
+     * <code>
+     * print_r($c->getTablesColumns());
+     *  => array(
+     *       'book' => array('book.price', 'book.title'),
+     *       'author' => array('author.first_name')
+     *     )
+     * </code>
+     *
+     * @return array array(table => array(table.column1, table.column2))
+     */
+    public function getTablesColumns(): array
+    {
+        $tables = [];
+        foreach ($this->criteria->filterCollector->getColumnFilters() as $filter) {
+            $tableName = $filter->getTableAlias();
+            $tables[$tableName][] = $filter->getLocalColumnName();
+        }
+        foreach ($this->criteria->updateValues->getColumnExpressionsInQuery() as $columnExpression) {
+            $tableName = substr($columnExpression, 0, strrpos($columnExpression, '.') ?: null);
+            $tables[$tableName][] = $columnExpression;
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @deprecated get update value (or filter) and resolve table alias manually.
+     *
+     * Method to return a String table name.
+     *
+     * @param string $name The name of the key.
+     *
+     * @return string|null The value of table for criterion at key.
+     */
+    public function getTableName(string $name): ?string
+    {
+        $updateColumn = $this->criteria->updateValues->getUpdateColumn($name);
+
+        return $updateColumn ? $updateColumn->getTableAlias() : null;
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::getUpdateValue()}.
+     *
+     * An alias to getValue() -- exposing a Hashtable-like interface.
+     *
+     * @param string $key An Object.
+     *
+     * @return mixed The value within the Criterion (not the Criterion object).
+     */
+    public function get(string $key)
+    {
+        return $this->criteria->getUpdateValue($key);
+    }
+
+    /**
+     * @deprecated Old interface should not be used anymore.
+     *
+     * Overrides Hashtable put, so that this object is returned
+     * instead of the value previously in the Criteria object.
+     * The reason is so that it more closely matches the behavior
+     * of the add() methods. If you want to get the previous value
+     * then you should first Criteria.get() it yourself. Note, if
+     * you attempt to pass in an Object that is not a String, it will
+     * throw a NPE. The reason for this is that none of the add()
+     * methods support adding anything other than a String as a key.
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria
+     */
+    public function put(string $key, $value)
+    {
+        return $this->criteria->addFilter($key, $value);
+    }
+
+    /**
+     * @deprecated old interface should not be used anymore.
+     *
+     * Copies all of the mappings from the specified Map to this Criteria
+     * These mappings will replace any mappings that this Criteria had for any
+     * of the keys currently in the specified Map.
+     *
+     * if the map was another Criteria, its attributes are copied to this
+     * Criteria, overwriting previous settings.
+     *
+     * @param mixed $t Mappings to be stored in this map.
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria
+     */
+    public function putAll($t)
+    {
+        if (is_array($t)) {
+            foreach ($t as $key => $value) {
+                if ($value instanceof ColumnFilterInterface) {
+                    $this->criteria->filterCollector->addFilter($value);
+                } else {
+                    $this->put($key, $value);
+                }
+            }
+        } elseif ($t instanceof Criteria) {
+            $this->criteria->joins = $t->joins;
+        }
+
+        return $this->criteria;
+    }
+
+    /**
+     * @deprecated old interface should not be used anymore.
+     *
+     * This method creates a new criterion but keeps it for later use with combine()
+     * Until combine() is called, the condition is not added to the query
+     *
+     * <code>
+     * $crit = new Criteria();
+     * $crit->addCond('cond1', $column1, $value1, Criteria::GREATER_THAN);
+     * $crit->addCond('cond2', $column2, $value2, Criteria::EQUAL);
+     * $crit->combine(array('cond1', 'cond2'), Criteria::LOGICAL_OR);
+     * </code>
+     *
+     * Any comparison can be used.
+     *
+     * The name of the table must be used implicitly in the column name,
+     * so the Column name must be something like 'TABLE.id'.
+     *
+     * @param string $name name to combine the criterion later
+     * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|string $columnOrClause The column to run the comparison on, or AbstractCriterion object.
+     * @param mixed|null $value
+     * @param string|null $comparison A String.
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria A modified Criteria object.
+     */
+    public function addCond(string $name, $columnOrClause, $value = null, ?string $comparison = null)
+    {
+        $this->namedCriterions[$name] = $this->criteria->buildFilter($columnOrClause, $value, $comparison);
+
+        return $this->criteria;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasCond(string $name): bool
+    {
+        return isset($this->namedCriterions[$name]);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface
+     */
+    public function getCond(string $name): ColumnFilterInterface
+    {
+        return $this->namedCriterions[$name];
+    }
+
+    /**
+     * Combine several named criterions with a logical operator
+     *
+     * @param array $criterions array of the name of the criterions to combine
+     * @param string $operator logical operator, either Criteria::LOGICAL_AND, or Criteria::LOGICAL_OR
+     * @param string|null $name optional name to combine the criterion later
+     *
+     * @throws \Propel\Runtime\Exception\LogicException
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria
+     */
+    public function combine(array $criterions = [], string $operator = self::LOGICAL_AND, ?string $name = null)
+    {
+        $namedCriterions = [];
+        foreach ($criterions as $key) {
+            if (array_key_exists($key, $this->namedCriterions)) {
+                $namedCriterions[] = $this->namedCriterions[$key];
+                unset($this->namedCriterions[$key]);
+            } else {
+                throw new LogicException(sprintf('Cannot combine unknown condition %s', $key));
+            }
+        }
+        $operatorMethod = (strtoupper($operator) === self::LOGICAL_AND) ? 'addAnd' : 'addOr';
+        $firstCriterion = array_shift($namedCriterions);
+        foreach ($namedCriterions as $criterion) {
+            $firstCriterion->$operatorMethod($criterion);
+        }
+        if ($name === null) {
+            $this->criteria->addAnd($firstCriterion, null, null);
+        } else {
+            $this->addCond($name, $firstCriterion, null, null);
+        }
+
+        return $this->criteria;
+    }
+
+    /**
+     * @deprecated use aptly named Criteria::addSubquery().
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $subQueryCriteria Criteria to build the subquery from
+     * @param string|null $alias alias for the subQuery
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criteria The current object, for fluid interface
+     */
+    public function addSelectQuery(Criteria $subQueryCriteria, ?string $alias = null)
+    {
+        return $this->criteria->addSubquery($subQueryCriteria, $alias);
+    }
+
+    /**
+     * @deprecated use aptly named {@see static::removeUpdateValue()}
+     *
+     * @param string $key A string with the key to be removed.
+     *
+     * @return mixed|null The removed value.
+     */
+    public function remove(string $key)
+    {
+        return $this->criteria->updateValues->removeUpdateValue($key);
+    }
+
+    /**
+     * @deprecated use {@see static::countColumnFilters()}
+     * or {@see static::countUpdateValues()}.
+     *
+     * Returns the size (count) of this criteria.
+     *
+     * @return int
+     */
+    public function size(): int
+    {
+        return $this->criteria->countColumnFilters() + $this->criteria->countUpdateValues();
+    }
+
+    /**
+     * @deprecated use aptly named {@see static::buildFilter()}
+     *
+     * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|string|null $columnOrClause A Criterion, or a SQL clause with a question mark placeholder, or a column name
+     * @param mixed|null $value The value to bind in the condition
+     * @param string|int|null $comparison A Criteria class constant, or a PDO::PARAM_ class constant
+     * @param bool $hasAccessToOutputColumns If AS columns can be used in the statement (for example in HAVING clauses)
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface
+     */
+    protected function getCriterionForCondition(
+        $columnOrClause,
+        $value = null,
+        $comparison = null,
+        bool $hasAccessToOutputColumns = false
+    ): ColumnFilterInterface {
+        return $this->criteria->buildFilter($columnOrClause, $value, $comparison, $hasAccessToOutputColumns);
+    }
+
+    /**
+     * @deprecated resolve the tableMap yourself and use Criteria::quoteColumnIdentifier().
+     *
+     * Quotes identifier based on $this->isIdentifierQuotingEnabled() and $tableMap->isIdentifierQuotingEnabled.
+     *
+     * @param string $string
+     * @param string $tableName
+     *
+     * @return string
+     */
+    public function quoteIdentifier(string $string, string $tableName = ''): string
+    {
+        if ($this->criteria->isIdentifierQuotingEnabled()) {
+            return $this->criteria->getAdapter()->quote($string);
+        }
+
+        //find table name and ask tableMap if quoting is enabled
+        $pos = strrpos($string, '.');
+        if (!$tableName && $pos !== false) {
+            $tableName = substr($string, 0, $pos);
+        }
+
+        $tableMapName = $this->criteria->getTableForAlias($tableName) ?: $tableName;
+
+        if ($tableMapName) {
+            $dbMap = $this->criteria->getDatabaseMap();
+            if ($dbMap->hasTable($tableMapName)) {
+                $tableMap = $dbMap->getTable($tableMapName);
+                if ($tableMap->isIdentifierQuotingEnabled()) {
+                    return $this->criteria->getAdapter()->quote($string);
+                }
+            }
+        }
+
+        return $string;
+    }
+
+    /**
+     * @deprecated use ModelCriteria::replaceColumnNames()
+     *
+     * @param string $sql
+     *
+     * @return bool
+     */
+    public function replaceNames(string &$sql): bool
+    {
+        $normalizedExpression = $this->criteria->normalizeFilterExpression($sql);
+        $sql = $normalizedExpression->getNormalizedFilterExpression();
+
+        return (bool)$normalizedExpression->getReplacedColumns();
+    }
+
+    /**
+     * @deprecated get primary keys in a reliable way from TableMap.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
+     *
+     * @return \Propel\Runtime\Map\ColumnMap|null
+     */
+    public function getPrimaryKey(?Criteria $criteria = null): ?ColumnMap
+    {
+        if (!$criteria) {
+            $criteria = $this->criteria;
+        }
+        // Assume all the keys are for the same table.
+        $key = $this->criteria->updateValues->getColumnExpressionsInQuery()[0];
+        $table = $criteria->getTableName($key);
+
+        $pk = null;
+
+        if ($table) {
+            $dbMap = Propel::getServiceContainer()->getDatabaseMap($criteria->getDbName());
+
+            $pks = $dbMap->getTable($table)->getPrimaryKeys();
+            if ($pks) {
+                $pk = array_shift($pks);
+            }
+        }
+
+        return $pk;
+    }
+
+    /**
+     * @deprecated get the filter or update value manually and lookup operator/comparison.
+     *
+     * Method to return a comparison String.
+     *
+     * @param string $key String name of the key.
+     *
+     * @return string|null A String with the value of the object at key.
+     */
+    public function getComparison(string $key): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Creates a Criterion object based on a list of existing condition names and a comparator
+     *
+     * @param array<string> $conditions The list of condition names, e.g. array('cond1', 'cond2')
+     * @param string|null $operator An operator, Criteria::LOGICAL_AND (default) or Criteria::LOGICAL_OR
+     *
+     * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface A Criterion or ModelCriterion object
+     */
+    protected function getCriterionForConditions(array $conditions, ?string $operator = null): ColumnFilterInterface
+    {
+        $operator = ($operator === null) ? Criteria::LOGICAL_AND : $operator;
+        $this->combine($conditions, $operator, 'propel_temp_name');
+        $criterion = $this->namedCriterions['propel_temp_name'];
+        unset($this->namedCriterions['propel_temp_name']);
+
+        return $criterion;
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -279,8 +279,6 @@ class DeprecatedCriteriaMethods extends Criteria
     }
 
     /**
-     * @deprecated old interface should not be used anymore.
-     *
      * This method creates a new criterion but keeps it for later use with combine()
      * Until combine() is called, the condition is not added to the query
      *

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -773,7 +773,7 @@ class DeprecatedCriteriaMethods extends Criteria
      * @param mixed $value
      * @param string|null $operator A String, like Criteria::EQUAL.
      *
-     * @return static
+     * @return \Propel\Runtime\ActiveQuery\Criteria
      */
     public function addUsingAlias(string $qualifiedColumnName, $value = null, ?string $operator = null)
     {

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -28,6 +28,16 @@ class DeprecatedCriteriaMethods extends Criteria
     protected $namedCriterions = [];
 
     /**
+     * @var bool
+     */
+    protected $useTransaction = false;
+
+    /**
+     * @var bool
+     */
+    protected $singleRecord = false;
+
+    /**
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      */
     public function __construct(Criteria $criteria)
@@ -59,6 +69,8 @@ class DeprecatedCriteriaMethods extends Criteria
     public function clear()
     {
         $this->namedCriterions = [];
+        $this->useTransaction = false;
+        $this->singleRecord = false;
 
         return $this->criteria;
     }
@@ -523,5 +535,71 @@ class DeprecatedCriteriaMethods extends Criteria
         unset($this->namedCriterions['propel_temp_name']);
 
         return $criterion;
+    }
+
+    /**
+     * @deprecated value is never used.
+     *
+     * Will force the sql represented by this criteria to be executed within
+     * a transaction. This is here primarily to support the oid type in
+     * postgresql. Though it can be used to require any single sql statement
+     * to use a transaction.
+     *
+     * @param bool $v
+     *
+     * @return $this
+     */
+    public function setUseTransaction(bool $v)
+    {
+        $this->useTransaction = $v;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated value is never used.
+     *
+     * Whether the sql command specified by this criteria must be wrapped
+     * in a transaction.
+     *
+     * @return bool
+     */
+    public function isUseTransaction(): bool
+    {
+        return $this->useTransaction;
+    }
+
+    /**
+     * @deprecated value is never used.
+     *
+     * Set single record? Set this to <code>true</code> if you expect the query
+     * to result in only a single result record (the default behaviour is to
+     * throw a PropelException if multiple records are returned when the query
+     * is executed). This should be used in situations where returning multiple
+     * rows would indicate an error of some sort. If your query might return
+     * multiple records but you are only interested in the first one then you
+     * should be using setLimit(1).
+     *
+     * @param bool $b Set to TRUE if you expect the query to select just one record.
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    public function setSingleRecord(bool $b)
+    {
+        $this->singleRecord = $b;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated value is never used.
+     *
+     * Is single record?
+     *
+     * @return bool True if a single record is being returned.
+     */
+    public function isSingleRecord(): bool
+    {
+        return $this->singleRecord;
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -370,7 +370,7 @@ class DeprecatedCriteriaMethods extends Criteria
      * @param \Propel\Runtime\ActiveQuery\Criteria $subQueryCriteria Criteria to build the subquery from
      * @param string|null $alias alias for the subQuery
      *
-     * @return \Propel\Runtime\ActiveQuery\Criteria The current object, for fluid interface
+     * @return \Propel\Runtime\ActiveQuery\Criteria
      */
     public function addSelectQuery(Criteria $subQueryCriteria, ?string $alias = null)
     {

--- a/src/Propel/Runtime/ActiveQuery/JoinBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/JoinBuilder.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery;
+
+use Propel\Runtime\ActiveQuery\FilterExpression\FilterFactory;
+
+/**
+ * Extracted from Criteria
+ */
+class JoinBuilder
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param string $left A String with the left side of the join.
+     * @param string $right A String with the right side of the join.
+     * @param string|null $joinType A String with the join operator
+     *                        among Criteria::INNER_JOIN, Criteria::LEFT_JOIN,
+     *                        and Criteria::RIGHT_JOIN
+     *
+     * @return \Propel\Runtime\ActiveQuery\Join
+     */
+    public static function buildJoin(Criteria $criteria, string $left, string $right, ?string $joinType = null): Join
+    {
+        $join = new Join();
+        $join->setIdentifierQuoting($criteria->isIdentifierQuotingEnabled());
+        $join->setJoinType($joinType);
+        [$leftTableName, $leftTableAlias, $leftColumnName] = static::extractColumnData($criteria, $left);
+        [$rightTableName, $rightTableAlias, $rightColumnName] = static::extractColumnData($criteria, $right);
+
+        $join->addExplicitCondition(
+            $leftTableName,
+            $leftColumnName,
+            $leftTableAlias,
+            $rightTableName,
+            $rightColumnName,
+            $rightTableAlias,
+            Join::EQUAL,
+        );
+
+        return $join;
+    }
+
+    /**
+     * Add a join with multiple conditions
+     *
+     * @see http://propel.phpdb.org/trac/ticket/167, http://propel.phpdb.org/trac/ticket/606
+     *
+     * Example usage:
+     * $c->addMultipleJoin([
+     *     [LeftTableMap::LEFT_COLUMN, RightTableMap::RIGHT_COLUMN], // if no third argument, defaults to Criteria::EQUAL
+     *     [FoldersTableMap::LFT, FoldersTableMap::RGT, Criteria::LESS_EQUAL ]
+     *   ],
+     *   Criteria::LEFT_JOIN
+     * );
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param array<array{0: string|mixed, 1: string|mixed, 2?: string|null}> $conditions An array of conditions, each condition being an array (left, right, operator)
+     * @param string|null $joinType A String with the join operator. Defaults to an implicit join.
+     *
+     * @return \Propel\Runtime\ActiveQuery\Join
+     */
+    public static function buildJoinWithMultipleConditions(Criteria $criteria, array $conditions, ?string $joinType = null): Join
+    {
+        $join = new Join();
+        $join->setIdentifierQuoting($criteria->isIdentifierQuotingEnabled());
+        $joinCondition = null;
+        foreach ($conditions as $condition) {
+            [$left, $right] = $condition;
+            [$leftTableName, $leftTableAlias, $leftColumnName] = static::extractColumnData($criteria, $left);
+            [$rightTableName, $rightTableAlias, $rightColumnName] = static::extractColumnData($criteria, $right);
+
+            if (!$join->getRightTableName()) {
+                $join->setRightTableName($rightTableName);
+            }
+
+            if (!$join->getRightTableAlias() && $rightTableAlias) {
+                $join->setRightTableAlias($rightTableAlias);
+            }
+
+            $leftSide = static::buildNameFromParts($leftTableName, $leftTableAlias, $leftColumnName);
+            $operator = $condition[2] ?? Join::EQUAL;
+            $rightSide = static::buildNameFromParts($rightTableName, $rightTableAlias, $rightColumnName);
+
+            $conditionClause = "$leftSide$operator$rightSide";
+            $fullColumnName = "$leftTableName.$leftColumnName";
+
+            $criterion = FilterFactory::build($criteria, $fullColumnName, Criteria::CUSTOM, $conditionClause);
+
+            if ($joinCondition === null) {
+                $joinCondition = $criterion;
+            } else {
+                $joinCondition->addAnd($criterion);
+            }
+        }
+        $join->setJoinType($joinType);
+        $join->setJoinCondition($joinCondition);
+
+        return $join;
+    }
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param string $columnIdentifier
+     *
+     * @return array{0: string|null, 1: string|null, 2: string}
+     */
+    protected static function extractColumnData(Criteria $criteria, string $columnIdentifier): array
+    {
+        $pos = strrpos($columnIdentifier, '.');
+        if (!$pos) {
+            return [null, null, $columnIdentifier];
+        }
+
+        $tableAlias = substr($columnIdentifier, 0, $pos);
+        $columnName = substr($columnIdentifier, $pos + 1);
+        [$tableName, $tableAlias] = $criteria->getTableNameAndAlias($tableAlias);
+
+        return [$tableName, $tableAlias, $columnName];
+    }
+
+    /**
+     * @param string|null $tableName
+     * @param string|null $tableAlias
+     * @param string $columnName
+     *
+     * @return string
+     */
+    protected static function buildNameFromParts(?string $tableName, ?string $tableAlias, string $columnName): string
+    {
+        return implode('.', array_filter([$tableName, $tableAlias, $columnName]));
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -148,7 +148,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param mixed $bindingType A value for the condition
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function condition(string $conditionName, string $clause, $value = null, $bindingType = null)
     {
@@ -169,7 +169,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param string|null $comparison What to use for the column comparison, defaults to Criteria::EQUAL or Criteria::IN for subqueries
      *
-     * @return static The current object, for fluid interface
+     * @return static
      */
     public function filterBy(string $columnPhpName, $value, ?string $comparison = null)
     {
@@ -193,7 +193,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param mixed $conditions An array of conditions, using column phpNames as key
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function filterByArray($conditions)
     {
@@ -228,7 +228,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function where($clause, $value = null, ?int $bindingType = null)
     {
@@ -306,7 +306,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function having($clause, $value = null, ?int $bindingType = null)
     {
@@ -338,7 +338,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\UnexpectedValueException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function orderBy(string $columnName, string $order = Criteria::ASC)
     {
@@ -378,7 +378,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function groupBy($columnNames)
     {
@@ -407,7 +407,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\ClassNotFoundException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function groupByClass(string $class)
     {
@@ -436,7 +436,7 @@ class ModelCriteria extends BaseModelCriteria
      * Adds a DISTINCT clause to the query
      * Alias for Criteria::setDistinct()
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function distinct()
     {
@@ -451,7 +451,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string|int $limit Maximum number of results to return by the query
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function limit($limit)
     {
@@ -466,7 +466,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string|int $offset Offset of the first result to return
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function offset($offset)
     {
@@ -497,7 +497,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function select($columnArray)
     {
@@ -605,7 +605,7 @@ class ModelCriteria extends BaseModelCriteria
      * @throws \Propel\Runtime\Exception\PropelException
      * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownRelationException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function join(string $relation, string $joinType = Criteria::INNER_JOIN)
     {
@@ -678,7 +678,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function addJoinCondition(string $name, string $clause, $value = null, ?string $operator = null, ?int $bindingType = null)
     {
@@ -712,7 +712,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function setJoinCondition(string $name, $condition)
     {
@@ -739,7 +739,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param \Propel\Runtime\ActiveQuery\Join $join A join object
      * @param string|null $name
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function addJoinObject(Join $join, ?string $name = null)
     {
@@ -769,7 +769,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $relation Relation to use for the join
      * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function joinWith(string $relation, ?string $joinType = null)
     {
@@ -802,7 +802,7 @@ class ModelCriteria extends BaseModelCriteria
      * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownRelationException
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function with(string $relation)
     {
@@ -854,7 +854,7 @@ class ModelCriteria extends BaseModelCriteria
      *                       If no alias is provided, the clause is used as a column alias
      *                       This alias is used for retrieving the column via BaseObject::getVirtualColumn($alias)
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function withColumn(string $clause, ?string $name = null)
     {
@@ -1141,7 +1141,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string|null $alias alias for the subQuery
      * @param bool $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function addSubquery(Criteria $subQuery, ?string $alias = null, bool $addAliasAndSelectColumns = true)
     {
@@ -1182,7 +1182,7 @@ class ModelCriteria extends BaseModelCriteria
     * @param string|null $alias alias for the subQuery
     * @param bool $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
     *
-    * @return static The current object, for fluid interface
+    * @return static
     */
     public function addSelectQuery(Criteria $subQueryCriteria, ?string $alias = null, bool $addAliasAndSelectColumns = true)
     {
@@ -1232,7 +1232,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param bool $force To enforce removing columns for changed alias, set it to true (f.e. with sub selects)
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function removeSelfSelectColumns(bool $force = false)
     {
@@ -1263,7 +1263,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string $relation The relation name or alias, as defined in join()
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function addRelationSelectColumns(string $relation)
     {
@@ -1330,7 +1330,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param bool $isKeepQuery
      *
-     * @return $this The current object, for fluid interface
+     * @return $this
      */
     public function keepQuery(bool $isKeepQuery = true)
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -198,12 +198,12 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @psalm-param literal-string|array $clause
      *
-     * @param array|string $clause A string representing the pseudo SQL clause, e.g. 'Book.AuthorId = ?'
+     * @param array<string>|string $clause A string representing the pseudo SQL clause, e.g. 'Book.AuthorId = ?'
      *   Or an array of condition names
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return $this
+     * @return static
      */
     public function where($clause, $value = null, ?int $bindingType = null)
     {
@@ -215,9 +215,7 @@ class ModelCriteria extends BaseModelCriteria
             $criterion = $this->buildFilterForClause($clause, $value, $bindingType);
         }
 
-        $this->addUsingOperator($criterion, null, null);
-
-        return $this;
+        return $this->addUsingOperator($criterion, null, null);
     }
 
     /**
@@ -237,15 +235,13 @@ class ModelCriteria extends BaseModelCriteria
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $existsQueryCriteria the query object used in the EXISTS statement
      * @param string $operator Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS. Defaults to EXISTS
      *
-     * @return $this
+     * @return static
      */
     public function whereExists(ActiveQueryModelCriteria $existsQueryCriteria, string $operator = ExistsQueryCriterion::TYPE_EXISTS)
     {
         $criterion = new ExistsQueryCriterion($this, null, $operator, $existsQueryCriteria);
 
-        $this->addUsingOperator($criterion);
-
-        return $this;
+        return $this->addUsingOperator($criterion);
     }
 
     /**
@@ -253,13 +249,11 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $existsQueryCriteria
      *
-     * @return $this
+     * @return static
      */
     public function whereNotExists(ActiveQueryModelCriteria $existsQueryCriteria)
     {
-        $this->whereExists($existsQueryCriteria, ExistsQueryCriterion::TYPE_NOT_EXISTS);
-
-        return $this;
+        return $this->whereExists($existsQueryCriteria, ExistsQueryCriterion::TYPE_NOT_EXISTS);
     }
 
     /**
@@ -276,12 +270,12 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @see Criteria::addHaving()
      *
-     * @param array|string $clause A string representing the pseudo SQL clause, e.g. 'Book.AuthorId = ?'
+     * @param array<string>|string $clause A string representing the pseudo SQL clause, e.g. 'Book.AuthorId = ?'
      *                      Or an array of condition names
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return $this
+     * @return static
      */
     public function having($clause, $value = null, ?int $bindingType = null)
     {
@@ -293,9 +287,7 @@ class ModelCriteria extends BaseModelCriteria
             $criterion = $this->buildFilterForClause($clause, $value, $bindingType);
         }
 
-        $this->addHaving($criterion);
-
-        return $this;
+        return $this->addHaving($criterion);
     }
 
     /**
@@ -313,7 +305,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\UnexpectedValueException
      *
-     * @return $this
+     * @return static
      */
     public function orderBy(string $columnName, string $order = Criteria::ASC)
     {
@@ -323,18 +315,12 @@ class ModelCriteria extends BaseModelCriteria
         $order = strtoupper($order);
         switch ($order) {
             case Criteria::ASC:
-                $this->addAscendingOrderByColumn($qualifiedColumnName);
-
-                break;
+                return $this->addAscendingOrderByColumn($qualifiedColumnName);
             case Criteria::DESC:
-                $this->addDescendingOrderByColumn($qualifiedColumnName);
-
-                break;
+                return $this->addDescendingOrderByColumn($qualifiedColumnName);
             default:
                 throw new UnexpectedValueException('ModelCriteria::orderBy() only accepts Criteria::ASC or Criteria::DESC as argument');
         }
-
-        return $this;
     }
 
     /**
@@ -403,49 +389,6 @@ class ModelCriteria extends BaseModelCriteria
                 $this->addGroupByColumn($column->getFullyQualifiedName());
             }
         }
-
-        return $this;
-    }
-
-    /**
-     * Adds a DISTINCT clause to the query
-     * Alias for Criteria::setDistinct()
-     *
-     * @return $this
-     */
-    public function distinct()
-    {
-        $this->setDistinct();
-
-        return $this;
-    }
-
-    /**
-     * Adds a LIMIT clause (or its subselect equivalent) to the query
-     * Alias for Criteria::setLimit()
-     *
-     * @param string|int $limit Maximum number of results to return by the query
-     *
-     * @return $this
-     */
-    public function limit($limit)
-    {
-        $this->setLimit((int)$limit);
-
-        return $this;
-    }
-
-    /**
-     * Adds an OFFSET clause (or its subselect equivalent) to the query
-     * Alias for of Criteria::setOffset()
-     *
-     * @param string|int $offset Offset of the first result to return
-     *
-     * @return $this
-     */
-    public function offset($offset)
-    {
-        $this->setOffset((int)$offset);
 
         return $this;
     }
@@ -807,14 +750,6 @@ class ModelCriteria extends BaseModelCriteria
         $this->with[$relation] = new ModelWith($join);
 
         return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isWithOneToMany(): bool
-    {
-        return $this->isWithOneToMany;
     }
 
     /**
@@ -2308,25 +2243,6 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
-     * @param string $andOr
-     * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|string $columnOrClause
-     * @param mixed $value
-     * @param string|int|null $condition
-     * @param bool $preferColumnCondition
-     *
-     * @return static
-     */
-    protected function addFilterWithConjunction(string $andOr, $columnOrClause, $value = null, $condition = null, bool $preferColumnCondition = true)
-    {
-        if (is_string($columnOrClause)) {
-            $resolvedColumn = $this->resolveColumn($columnOrClause);
-            $columnOrClause = $resolvedColumn;
-        }
-
-        return parent::addFilterWithConjunction($andOr, $columnOrClause, $value, $condition, $preferColumnCondition);
-    }
-
-    /**
      * @deprecated just use ModelCriteria::addUsingOperator(), local columns will be resolved anyway.
      *
      * Overrides Criteria::add() to force the use of a true table alias if it exists
@@ -2335,15 +2251,14 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value
      * @param string|null $operator A String, like Criteria::EQUAL.
      *
-     * @return $this A modified Criteria object.
+     * @return static
      */
     public function addUsingAlias(string $qualifiedColumnName, $value = null, ?string $operator = null)
     {
         $columnName = substr($qualifiedColumnName, (int)strrpos($qualifiedColumnName, '.') + 1);
         $resolvedColumn = $this->resolveLocalColumnByName($columnName);
-        $this->addUsingOperator($resolvedColumn, $value, $operator);
 
-        return $this;
+        return $this->addUsingOperator($resolvedColumn, $value, $operator);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -2434,7 +2434,6 @@ class ModelCriteria extends BaseModelCriteria
     public function buildBindParams(): array
     {
         $params = [];
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
 
         foreach ($this->filterCollector->getColumnFilters() as $filter) {
             $filter->collectParameters($params);
@@ -2442,7 +2441,6 @@ class ModelCriteria extends BaseModelCriteria
 
         $having = $this->getHaving();
         if ($having !== null) {
-            $sb = '';
             $having->collectParameters($params);
         }
 

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -151,7 +151,7 @@ class ModelJoin extends Join
      *
      * @param \Propel\Runtime\Map\TableMap $tableMap The table map to use
      *
-     * @return $this The current join object, for fluid interface
+     * @return $this
      */
     public function setTableMap(TableMap $tableMap)
     {

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
@@ -42,15 +42,16 @@ class InsertQueryExecutor extends AbstractQueryExecutor
     protected function findTableMapFromValues(): ?TableMap
     {
         $columnName = $this->criteria->getUpdateValues()->getColumnExpressionsInQuery()[0];
-        $table = $this->criteria->getTableName($columnName);
+        $updateColumn = $this->criteria->getUpdateValues()->getUpdateColumn($columnName);
+        $tableAlias = $updateColumn ? $updateColumn->getTableAlias() : null;
 
-        if (!$table) {
+        if (!$tableAlias) {
             return null;
         }
 
         $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->criteria->getDbName());
 
-        return $dbMap->getTable($table);
+        return $dbMap->getTable($tableAlias);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaIsEmptyTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaIsEmptyTest.php
@@ -29,7 +29,7 @@ class CriteriaIsEmptyTest extends TestCaseFixtures
             ['select modifier', false, (new Criteria())->addSelectModifier('DISTINCT')],
             ['column filters', false, (new Criteria())->addFilter('id', 5)],
             ['having', false, (new Criteria())->addHaving('id')],
-            ['join', false, (new Criteria())->addJoin('l', 'r')],
+            ['join', false, (new Criteria())->addJoin('l.id', 'r.id')],
             ['update values', false, (new Criteria())->setUpdateValue('id', 3, \PDO::PARAM_STR)],
             
             ['select', false, (new ModelCriteria())->select('id')],

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1215,7 +1215,7 @@ class CriteriaTest extends BookstoreTestBase
 
         $this->assertFalse($c->getIgnoreCase(), 'ignoreCase is false by default');
 
-        $this->assertFalse($c->getSingleRecord(), 'singleRecord is false by default');
+        $this->assertFalse($c->isSingleRecord(), 'singleRecord is false by default');
 
         $this->assertTrue(is_array($c->getSelectModifiers()), 'selectModifiers is an array');
         $this->assertEquals(0, count($c->getSelectModifiers()), 'selectModifiers is empty by default');
@@ -1247,7 +1247,7 @@ class CriteriaTest extends BookstoreTestBase
         $this->assertTrue(is_array($c->getAliases()), 'aliases is an array');
         $this->assertEquals(0, count($c->getAliases()), 'aliases is empty by default');
 
-        $this->assertFalse($c->getUseTransaction(), 'useTransaction is false by default');
+        $this->assertFalse($c->isUseTransaction(), 'useTransaction is false by default');
 
         $this->assertNull($c->getLock(), 'lock is null by default');
     }
@@ -1435,15 +1435,5 @@ class CriteriaForClearTest extends Criteria
     public function getIgnoreCase()
     {
         return $this->ignoreCase;
-    }
-
-    public function getSingleRecord()
-    {
-        return $this->singleRecord;
-    }
-
-    public function getUseTransaction()
-    {
-        return $this->useTransaction;
     }
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1431,10 +1431,6 @@ class CriteriaTest extends BookstoreTestBase
 
 class CriteriaForClearTest extends Criteria
 {
-    public function getNamedCriterions()
-    {
-        return $this->namedCriterions;
-    }
 
     public function getIgnoreCase()
     {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2910,64 +2910,64 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testAddUsingAliasNoAlias()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c2->add(BookTableMap::COL_TITLE, 'foo');
-        $this->assertEquals($c2, $c1, 'addUsingalias() translates to add() when the table has no alias');
+        $c2->addFilter(BookTableMap::COL_TITLE, 'foo');
+        $this->assertEquals($c2, $c1, 'addUsingOperator() translates to add() when the table has no alias');
     }
 
     /**
      * @return void
      */
-    public function testAddUsingAliasQueryAlias()
+    public function testAddUsingOperatorQueryAlias()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
-        $c2->add(BookTableMap::COL_TITLE, 'foo');
-        $this->assertEquals($c2, $c1, 'addUsingalias() translates the colname using the table alias before calling add() when the table has a true alias');
+        $c2->addFilter(BookTableMap::COL_TITLE, 'foo');
+        $this->assertEquals($c2, $c1, 'addUsingOperator() translates the colname using the table alias before calling add() when the table has a true alias');
     }
 
     /**
      * @return void
      */
-    public function testAddUsingAliasTrueAlias()
+    public function testAddUsingOperatorTrueAlias()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c1->setModelAlias('b', true);
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c2->setModelAlias('b', true);
-        $c2->add('b.title', 'foo');
-        $this->assertEquals($c2, $c1, 'addUsingalias() translates to add() when the table has a true alias');
+        $c2->addFilter('b.title', 'foo');
+        $this->assertEquals($c2, $c1, 'addUsingOperator() translates to add() when the table has a true alias');
     }
 
     /**
      * @return void
      */
-    public function testAddUsingAliasTwice()
+    public function testAddUsingOperatorTwice()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'bar');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'bar');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c2->add(BookTableMap::COL_TITLE, 'foo');
+        $c2->addFilter(BookTableMap::COL_TITLE, 'foo');
         $c2->addAnd(BookTableMap::COL_TITLE, 'bar');
-        $this->assertEquals($c2, $c1, 'addUsingalias() translates to addAnd() when the table already has a condition on the column');
+        $this->assertEquals($c2, $c1, 'addUsingOperator() translates to addAnd() when the table already has a condition on the column');
     }
 
     /**
      * @return void
      */
-    public function testAddUsingAliasTrueAliasTwice()
+    public function testAddUsingOperatorTrueAliasTwice()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c1->setModelAlias('b', true);
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
-        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'bar');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingOperator(BookTableMap::COL_TITLE, 'bar');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c2->setModelAlias('b', true);
-        $c2->add('b.title', 'foo');
+        $c2->addFilter('b.title', 'foo');
         $c2->addAnd('b.title', 'bar');
         $this->assertEquals($c2, $c1, 'addUsingalias() translates to addAnd() when the table already has a condition on the column');
     }

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -60,7 +60,7 @@ class TableMapExceptionsTest extends BookstoreTestBase
         $c1->setUpdateValue(BookTableMap::COL_ID, 12);
 
         $c1->setUpdateValue('book.unknown_column', 'Foo', \PDO::PARAM_STR);
-        $this->expectException(\Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException::class);
+        $this->expectException(QueryExecutionException::class);
         $c1->doUpdate(null,$this->con);
     }
 


### PR DESCRIPTION
Removes old Criteria/ModelCriteria methods. The methods are put into a new class and are called from there via magic `__call` with a deprecation warning.

Main reasons for deprecation are:
 - method likely intended for internal use only, but is not used
 - confusing name
 -  deprecated or unimplemented functionality 

| method | reason for deprecation | replace with |
|---|---|---|
| getMap() | `map` was split into `updateValues` and `filterCollector` | `getUpdateValues()` or `getFilterCollector()` |
| keys() | naming, no more map | use `array_keys()` on  `getUpdateValues()` or `getFilterCollector()` |
| containsKey() | checks if `map` has an update value | `hasUpdateValue()` |
| keyContainsValue() | checks if update value is actually a value | `getUpdateValue() === null` |
| getCriterion() | naming, no more map | `findFilterByColumn()` or `getUpdateValueForColumn() |
| getLastCriterion() | naming | `getLastFilter()` |
| getTablesColumns() | no more map | `getUpdateValuesByTable()` or `getFiltersByTable()` |
| getTableName() | unclear usage | manually get update value and call `getTableAlias()` on it |
| get() | no more map, naming | `getUpdateValue()` |
| put() | no more map, naming | `addFilter() or ``setUpdateValue()` |
| putAll() | no more map, naming | own loop |
| addCond() | naming filters should not be necessary/is not useful | add filter directly |
| condition | duplicate of addCond() | |
| hasCond() | naming filters should not be necessary/is not useful | add filter directly |
| getCond() | naming filters should not be necessary/is not useful | add filter directly |
| combine() | naming filters should not be necessary/is not useful | add filter directly |
| getNamedCriterions() | naming filters should not be necessary/is not useful | add filter directly |
| getCriterionForConditions() | naming filters should not be necessary/is not useful | add filter directly |
| getCriterionForClause() | naming | use `buildFilterForClause()` |
| addSelectQuery() | naming | `addSubquery()` |
| remove() | no more map, naming | `removeUpdateValue()` (or, better, don't add what you don't want) |
| size() | no more map, naming | `countColumnFilters()` |
| getCriterionForCondition() | naming | `buildFilter()` |
| quoteIdentifier() | naming, does unrelated things (tries to resolve TableMap) | resolve TableMap yourself and use `quoteColumnIdentifier()` |
| replaceNames() | naming | `replaceColumnNames()` |
| getPrimaryKey() | naming, particular/sole usage in InsertQueryExecutor | get PK from TableMap |
| getComparison() | peculiar/questionable internal use-case | something meaningful | 
| setUseTransaction() | no internal usage | remove |
| isUseTransaction()  | no internal usage | remove |
| setSingleRecord()  | no internal usage | remove |
| isSingleRecord()  | no internal usage | remove |
| isWithOneToMany() | no internal usage | remove |
| convertValueForColumn() | duplicated code | `FilterClauseLiteralWithColumns::convertValueForColumn()` |
| getColumnFromName() | naming | `resolveColumn()` |
| getColumnMapByColumnName() | naming (uses PhpName), unused | `getTableMapOrFail()` and find column manually |
| getRealColumnName() | naming, unused, limited functionality | build alias manually |
| getParams() | unused, unclear usage | build params from filters, having etc. |
| buildBindParams() | alias for getParams() |  |
| addUsingAlias() | naming, duplicate | use `addUsingOperator()` |

Test on those methods are mostly unchanged, they still work.

Also moved code of `addJoin()` into static class, and removed some meaningless descriptions from docblocks (''). 