### PR TITLE
add typed find() methods

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -20,6 +20,8 @@ use Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface;
 use Propel\Runtime\ActiveQuery\FilterExpression\ColumnToQueryFilter;
 use Propel\Runtime\ActiveQuery\FilterExpression\ExistsFilter;
 use Propel\Runtime\ActiveQuery\ModelCriteria as ActiveQueryModelCriteria;
+use Propel\Runtime\Collection\ArrayCollection;
+use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\ClassNotFoundException;
@@ -1284,6 +1286,34 @@ class ModelCriteria extends BaseModelCriteria
         $dataFetcher = $criteria->fetch($con);
 
         return $criteria->getFormatter()->init($criteria)->format($dataFetcher);
+    }
+
+    /**
+     * Same as find(), but returns a typed ObjectCollection.
+     *
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return \Propel\Runtime\Collection\ObjectCollection<\Propel\Runtime\ActiveRecord\ActiveRecordInterface>
+     */
+    public function findObjects(?ConnectionInterface $con = null): ObjectCollection
+    {
+        $this->setFormatter(static::FORMAT_OBJECT);
+
+        return $this->find($con);
+    }
+
+    /**
+     * Same as find(), but returns a (typed) ArrayCollection.
+     *
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return \Propel\Runtime\Collection\ArrayCollection
+     */
+    public function findTuples(?ConnectionInterface $con = null): ArrayCollection
+    {
+        $this->setFormatter(static::FORMAT_ARRAY);
+
+        return $this->find($con);
     }
 
     /**

--- a/templates/Builder/Om/baseQueryClassHeader.php
+++ b/templates/Builder/Om/baseQueryClassHeader.php
@@ -79,6 +79,7 @@
  *
  * @method     <?= $modelClass ?>[]|Collection find(?ConnectionInterface $con = null) Return <?= $modelClass ?> objects based on current ModelCriteria
  * @psalm-method Collection&\Traversable<<?= $modelClass ?>> find(?ConnectionInterface $con = null) Return <?= $modelClass ?> objects based on current ModelCriteria
+ * @method     \Propel\Runtime\Collection\ObjectCollection<<?= $modelClass ?>> findObjects(?ConnectionInterface $con = null) Get <?= $modelClass ?> objects in ObjectCollection
  *
 <?php foreach($columns as $column):?>
  * @method     <?= $modelClass ?>[]|Collection findBy<?= $column->getPhpName() ?>(<?= $column->getPhpType() ?>|array<<?= $column->getPhpType() ?>> $<?= $column->getName() ?>) Return <?= $modelClass ?> objects filtered by the <?= $column->getName() ?> column

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaFormatterTest.php
@@ -9,6 +9,8 @@
 namespace Propel\Tests\Runtime\ActiveQuery;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\Collection\ArrayCollection;
+use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Exception\InvalidArgumentException;
 use Propel\Runtime\Formatter\AbstractFormatter;
 use Propel\Runtime\Formatter\ArrayFormatter;
@@ -197,4 +199,24 @@ class ModelCriteriaFormatterTest extends BookstoreTestBase
         $formatter2->test = true;
         $this->assertFalse($formatter1->test);
     }
+
+    /**
+     * @return void
+     */
+    public function testFindObjects()
+    {
+        $collection = BookQuery::create()->findObjects();
+        $this->assertInstanceOf(ObjectCollection::class, $collection);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindTuples()
+    {
+        $collection = BookQuery::create()->findTuples();
+        $this->assertInstanceOf(ArrayCollection::class, $collection);
+    }
+
+
 }


### PR DESCRIPTION
Adds typed `find()` methods to query objects.
```php
$books = BookQuery::create()->findObjects(); // returns ObjectCollection<Book>
$book = $books->get(1); // will be Book

$books = BookQuery::create()->findTuples(); // returns ArrayCollection
$book = $books->get(1); // will be array<string, mixed>
```