### PR TITLE
Restore parent query type after endUse()

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
     errorLevel="6"
     allowStringToStandInForClass="true"
     usePhpDocMethodsWithoutMagicCall="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -62,6 +62,9 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
  * You should add additional methods to this class to meet the
  * application requirements.  This class will only be generated as
  * long as it does not already exist in the output directory.
+ *
+ * @template ParentQuery extends \Propel\Runtime\ActiveQuery\TypedModelCriteria|null = null
+ * @extends $baseClassName<ParentQuery>
  */";
         }
         $script .= "

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -79,7 +79,7 @@ class QueryBuilder extends AbstractOMBuilder
             return $baseQueryClass;
         }
 
-        return 'ModelCriteria';
+        return 'TypedModelCriteria';
     }
 
     /**
@@ -169,6 +169,7 @@ class QueryBuilder extends AbstractOMBuilder
         $this->declareClasses(
             '\Propel\Runtime\Propel',
             '\Propel\Runtime\ActiveQuery\ModelCriteria',
+            '\Propel\Runtime\ActiveQuery\TypedModelCriteria',
             '\Propel\Runtime\ActiveQuery\Criteria',
             '\Propel\Runtime\ActiveQuery\FilerExpression\FilterFactory',
             '\Propel\Runtime\ActiveQuery\ModelJoin',
@@ -440,7 +441,7 @@ class QueryBuilder extends AbstractOMBuilder
      * @param string \$modelAlias The alias of a model in the query
      * @param Criteria \$criteria Optional Criteria to build the query from
      *
-     * @return " . $classname . "
+     * @return " . $classname . "<null>
      */";
     }
 
@@ -1602,11 +1603,11 @@ class QueryBuilder extends AbstractOMBuilder
      *                                   to be used as main alias in the secondary query
      * @param string \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return $queryClass A secondary query class using the current class as primary query
+     * @return $queryClass<static> A secondary query class using the current class as primary query
      */
     public function use" . $relationName . 'Query($relationAlias = null, $joinType = ' . $joinType . ")
     {
-        /** @var $queryClass \$query */
+        /** @var $queryClass<static> \$query */
         \$query = \$this->join" . $relationName . "(\$relationAlias, \$joinType)
             ->useQuery(\$relationAlias ?: '$relationName', '$queryClass');
 

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -130,7 +130,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @throws \Propel\Runtime\Exception\InvalidArgumentException
      *
-     * @return $this
+     * @return static
      */
     public function setFormatter($formatter)
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1011,7 +1011,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $criteria The primary criteria
      * @param \Propel\Runtime\ActiveQuery\Join|null $previousJoin The previousJoin for this ModelCriteria
      *
-     * @return $this
+     * @return static
      */
     public function setPrimaryCriteria(ModelCriteria $criteria, ?Join $previousJoin)
     {

--- a/src/Propel/Runtime/ActiveQuery/TypedModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/TypedModelCriteria.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Propel\Runtime\ActiveQuery;
+
+/**
+ * Adds a generic type to ModelCriteria for type-safe use of endUse(). Used as
+ * parent class for Query classes.
+ *
+ * This class is not meant to implement methods.
+ *
+ * @template ParentQuery of \Propel\Runtime\ActiveQuery\ModelCriteria|null = null
+ *
+ * @method ParentQuery endUse()
+ */
+class TypedModelCriteria extends ModelCriteria
+{
+}

--- a/templates/Builder/Om/baseQueryClassHeader.php
+++ b/templates/Builder/Om/baseQueryClassHeader.php
@@ -59,10 +59,6 @@
  * @method     <?= $queryClass ?> innerJoinWith<?= $relationName ?>() Adds a INNER JOIN clause and with to the query using the <?= $relationName ?> relation
  *
 <?php endforeach; ?>
-<?php if($relatedTableQueryClassNames): ?>
- * @method     <?= implode('|', $relatedTableQueryClassNames) ?> endUse() Finalizes a secondary criteria and merges it with its primary Criteria
- *
-<?php endif; ?>
  * @method     <?= $modelClass ?>|null findOne(?ConnectionInterface $con = null) Return the first <?= $modelClass ?> matching the query
  * @method     <?= $modelClass ?> findOneOrCreate(?ConnectionInterface $con = null) Return the first <?= $modelClass ?> matching the query, or a new <?= $modelClass ?> object populated from the query conditions when no match is found
  *
@@ -88,6 +84,9 @@
  *
  * @method     <?= $modelClass ?>[]|\Propel\Runtime\Util\PropelModelPager paginate($page = 1, $maxPerPage = 10, ?ConnectionInterface $con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
  * @psalm-method \Propel\Runtime\Util\PropelModelPager&\Traversable<<?= $modelClass ?>> paginate($page = 1, $maxPerPage = 10, ?ConnectionInterface $con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
+ *
+ * @template ParentQuery of ModelCriteria|null = null
+ * @extends <?= $parentClass ?><ParentQuery>
  */
 abstract class <?= $unqualifiedClassName ?> extends <?= $parentClass ?> 
 {

--- a/templates/Builder/Om/baseQueryExistsMethods.php
+++ b/templates/Builder/Om/baseQueryExistsMethods.php
@@ -8,11 +8,11 @@
      * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
      * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
      *
-     * @return <?= $queryClass ?> The inner query object of the EXISTS statement
+     * @return <?= $queryClass ?><static> The inner query object of the EXISTS statement
      */
     public function use<?= $relationName ?>ExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = '<?= $existsType ?>')
     {
-        /** @var <?= $queryClass ?> $q */
+        /** @var <?= $queryClass ?><static> $q */
         $q = $this->useExistsQuery('<?= $relationName ?>', $modelAlias, $queryClass, $typeOfExists);
 
         return $q;
@@ -26,11 +26,11 @@
      * @param string|null $modelAlias sets an alias for the nested query
      * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
      *
-     * @return <?= $queryClass ?> The inner query object of the NOT EXISTS statement
+     * @return <?= $queryClass ?><static> The inner query object of the NOT EXISTS statement
      */
     public function use<?= $relationName ?>NotExistsQuery($modelAlias = null, $queryClass = null)
     {
-        /** @var <?= $queryClass ?> $q*/
+        /** @var <?= $queryClass ?><static> $q*/
         $q = $this->useExistsQuery('<?= $relationName ?>', $modelAlias, $queryClass, '<?= $notExistsType ?>');
 
         return $q;

--- a/templates/Builder/Om/baseQueryInMethods.php
+++ b/templates/Builder/Om/baseQueryInMethods.php
@@ -8,11 +8,11 @@
      * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
      * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
      *
-     * @return <?= $queryClass ?> The inner query object of the IN statement
+     * @return <?= $queryClass ?><static> The inner query object of the IN statement
      */
     public function useIn<?= $relationName ?>Query($modelAlias = null, $queryClass = null, $typeOfIn = '<?= $inType ?>')
     {
-        /** @var <?= $queryClass ?> $q */
+        /** @var <?= $queryClass ?><static> $q */
         $q = $this->useInQuery('<?= $relationName ?>', $modelAlias, $queryClass, $typeOfIn);
         return $q;
     }
@@ -25,11 +25,11 @@
      * @param string|null $modelAlias sets an alias for the nested query
      * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
      *
-     * @return <?= $queryClass ?> The inner query object of the NOT IN statement
+     * @return <?= $queryClass ?><static> The inner query object of the NOT IN statement
      */
     public function useNotIn<?= $relationName ?>Query($modelAlias = null, $queryClass = null)
     {
-        /** @var <?= $queryClass ?> $q */
+        /** @var <?= $queryClass ?><static> $q */
         $q = $this->useInQuery('<?= $relationName ?>', $modelAlias, $queryClass, '<?= $notInType ?>');
         return $q;
     }

--- a/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
@@ -101,7 +101,7 @@ EOF;
         $this->assertStringContainsString('class QuickBuildFoo1 extends BaseQuickBuildFoo1', $script);
         $this->assertStringContainsString('class QuickBuildFoo1Query extends BaseQuickBuildFoo1Query', $script);
         $this->assertStringContainsString('class QuickBuildFoo1 implements ActiveRecordInterface', $script);
-        $this->assertStringContainsString('class QuickBuildFoo1Query extends ModelCriteria', $script);
+        $this->assertStringContainsString('class QuickBuildFoo1Query extends TypedModelCriteria', $script);
     }
 
     /**
@@ -115,7 +115,7 @@ EOF;
         $this->assertStringNotContainsString('class QuickBuildFoo1 extends BaseQuickBuildFoo1', $script);
         $this->assertStringNotContainsString('class QuickBuildFoo1Query extends BaseQuickBuildFoo1Query', $script);
         $this->assertStringContainsString('class QuickBuildFoo1 implements ActiveRecordInterface', $script);
-        $this->assertStringContainsString('class QuickBuildFoo1Query extends ModelCriteria', $script);
+        $this->assertStringContainsString('class QuickBuildFoo1Query extends TypedModelCriteria', $script);
     }
 
     /**


### PR DESCRIPTION
Allows to restore parent query type after `endUse()`:
```php
$b = BookQuery::create();                              // BookQuery<null>
$b = $b->useAuthorQuery();                             // AuthorQuery<BookQuery<null>>
$b = $b->useEssayRelatedByFirstAuthorIdExistsQuery();  // EssayQuery<AuthorQuery<BookQuery<null>>>
$b = $b->endUse();                                     // AuthorQuery<BookQuery<null>>
$b = $b->endUse();                                     // BookQuery<null>
```
A generic parameter is added through a new child class of ModelCriteria (`TypedModelCriteria`) which is set as parent class to the query classes. The current class is set as type parameter to the class returned by `useXXXQuery()` and unwrapped on `endUse()`.

Extending ModelCriteria and adding a type parameter to all query classes is a substantial change. It is mitigated by query classes usually being instantiated through `create()`, which can be typed easily. Still, it is hard (for me) to say with certainty that this has no other, possibly bad, impact.

A correct implementation also requires the child classes of the base object classes to declare the generic parameter. This is no problem for automatically created stub classes, but has to be done manually for existing classes (or accept stan/psalm complaining).

Ultimately, this is a workaround for the bulky PHP type system to get code completion and type checking on the `useXXX()` methods, which is a nice feature, but it needs to be monitored for downsides and possibly rolled back.